### PR TITLE
MWOS-27: Passay dictionary tests required more than 256m of heap, 512m s...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
         <configuration>
-          <argLine>-Xms128m -Xmx256m</argLine>
+          <argLine>-Xms128m -Xmx512m</argLine>
           <suiteXmlFiles>
             <suiteXmlFile>${testng.dir}/testng.xml</suiteXmlFile>
           </suiteXmlFiles>


### PR DESCRIPTION
...eems to be sufficient to build without fail in our CI environment.
