### PR TITLE
Added common special characters present on various English keyboards

### DIFF
--- a/src/main/java/org/passay/EnglishCharacterData.java
+++ b/src/main/java/org/passay/EnglishCharacterData.java
@@ -21,7 +21,7 @@ public enum EnglishCharacterData implements CharacterData {
   Alphabetical("INSUFFICIENT_ALPHABETICAL", UpperCase.getCharacters() + LowerCase.getCharacters()),
 
   /** Alphabetical characters (upper and lower case). */
-  Special("INSUFFICIENT_SPECIAL", "`~@#$%^&*()-_=+[{]}\\|;:'\",<.>/?");
+  Special("INSUFFICIENT_SPECIAL", "§¬±`~@#$¢£€%^&*()-_=+[{]}\\|;:'\",<.>/?¼½¾");
 
 
   /** Error code. */

--- a/src/test/java/org/passay/CharacterCharacteristicsRuleTest.java
+++ b/src/test/java/org/passay/CharacterCharacteristicsRuleTest.java
@@ -15,7 +15,10 @@ public class CharacterCharacteristicsRuleTest extends AbstractRuleTest
 {
 
   /** Test password. */
-  private static final String VALID_PASS = "r%scvEW2e93)";
+  private static final String VALID_PASS_1 = "r%scvEW2e93)";
+
+  /** Test password. */
+  private static final String VALID_PASS_2 = "r£scvEW2e93";
 
   /** Test password. */
   private static final String ALPHA_PASS = "r%5#8EW2393)";
@@ -70,7 +73,16 @@ public class CharacterCharacteristicsRuleTest extends AbstractRuleTest
     return
       new Object[][] {
 
-        {rule1, new PasswordData(VALID_PASS), null, },
+        {rule1, new PasswordData(VALID_PASS_1), null, },
+        {
+          rule1,
+          new PasswordData(ALPHA_PASS),
+          codes(
+            CharacterCharacteristicsRule.ERROR_CODE,
+            EnglishCharacterData.Alphabetical.getErrorCode(),
+            EnglishCharacterData.LowerCase.getErrorCode()),
+        },
+        {rule1, new PasswordData(VALID_PASS_2), null, },
         {
           rule1,
           new PasswordData(ALPHA_PASS),
@@ -99,7 +111,8 @@ public class CharacterCharacteristicsRuleTest extends AbstractRuleTest
           new PasswordData(NONALPHA_PASS),
           codes(CharacterCharacteristicsRule.ERROR_CODE, EnglishCharacterData.Special.getErrorCode()),
         },
-        {rule2, new PasswordData(VALID_PASS), null, },
+        {rule2, new PasswordData(VALID_PASS_1), null, },
+        {rule2, new PasswordData(VALID_PASS_2), null, },
         {rule2, new PasswordData(ALPHA_PASS), null, },
         {rule2, new PasswordData(DIGIT_PASS), null, },
         {rule2, new PasswordData(UPPERCASE_PASS), null, },
@@ -116,7 +129,7 @@ public class CharacterCharacteristicsRuleTest extends AbstractRuleTest
   {
     final CharacterCharacteristicsRule ccr = new CharacterCharacteristicsRule();
     try {
-      ccr.validate(new PasswordData(VALID_PASS));
+      ccr.validate(new PasswordData(VALID_PASS_1));
       AssertJUnit.fail("Should have thrown IllegalStateException");
     } catch (Exception e) {
       AssertJUnit.assertEquals(IllegalStateException.class, e.getClass());


### PR DESCRIPTION

I noticed that some special characters present on a number of non-US English keyboards are not present in the EnglishCharacterData class. This causes an unnecessary error during password update for users who had chosen a special character from their keyboard. Therefore, I have extended the list of special characters in the EnglishCharacterData class to include some common characters. 

Keyboard layouts for various English keyboards can be found at https://en.wikipedia.org/wiki/QWERTY 
 
Change set of the special-characters branch is a simple solution that is likely to prevent errors for many users. However, it is not a complete solution as a user may choose some other character. A better solution will be to introduce  a concept of non-alpha-numeric characters for a chosen language. It can be implemented as a separate rule if desired.

Best wishes,

Vaibhav