### PR TITLE
ISSUE-37 improve precision of ShannonEntropyFactory

### DIFF
--- a/src/main/java/org/passay/AbstractDictionaryRule.java
+++ b/src/main/java/org/passay/AbstractDictionaryRule.java
@@ -33,6 +33,9 @@ public abstract class AbstractDictionaryRule implements Rule
    */
   public void setDictionary(final Dictionary dict)
   {
+    if (dict == null) {
+      throw new NullPointerException("Dictionary cannot be null");
+    }
     dictionary = dict;
   }
 

--- a/src/main/java/org/passay/dictionary/Dictionary.java
+++ b/src/main/java/org/passay/dictionary/Dictionary.java
@@ -18,4 +18,11 @@ public interface Dictionary
    * @return  whether word was found
    */
   boolean search(String word);
+
+  /**
+   * Returns the number of words in this dictionary
+   *
+   * @return  total number of words to search
+   */
+  long size();
 }

--- a/src/main/java/org/passay/dictionary/Dictionary.java
+++ b/src/main/java/org/passay/dictionary/Dictionary.java
@@ -19,6 +19,7 @@ public interface Dictionary
    */
   boolean search(String word);
 
+
   /**
    * Returns the number of words in this dictionary
    *

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -87,6 +87,11 @@ public class TernaryTreeDictionary implements Dictionary
     tree = tt;
   }
 
+  @Override
+  public long size()
+  {
+    return tree == null ? 0 : tree.getWords().size();
+  }
 
   @Override
   public boolean search(final String word)

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -87,11 +87,13 @@ public class TernaryTreeDictionary implements Dictionary
     tree = tt;
   }
 
+
   @Override
   public long size()
   {
     return tree == null ? 0 : tree.getWords().size();
   }
+
 
   @Override
   public boolean search(final String word)

--- a/src/main/java/org/passay/dictionary/WordListDictionary.java
+++ b/src/main/java/org/passay/dictionary/WordListDictionary.java
@@ -42,11 +42,13 @@ public class WordListDictionary implements Dictionary
     return wordList;
   }
 
+
   @Override
   public long size()
   {
     return wordList == null ? 0 : wordList.size();
   }
+
 
   @Override
   public boolean search(final String word)

--- a/src/main/java/org/passay/dictionary/WordListDictionary.java
+++ b/src/main/java/org/passay/dictionary/WordListDictionary.java
@@ -42,6 +42,11 @@ public class WordListDictionary implements Dictionary
     return wordList;
   }
 
+  @Override
+  public long size()
+  {
+    return wordList == null ? 0 : wordList.size();
+  }
 
   @Override
   public boolean search(final String word)

--- a/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
@@ -1,10 +1,14 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.entropy;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.passay.AbstractDictionaryRule;
+import org.passay.CharacterCharacteristicsRule;
+import org.passay.CharacterRule;
+import org.passay.EnglishCharacterData;
 import org.passay.PasswordData;
+import org.passay.PasswordValidator;
 import org.passay.Rule;
 
 /**
@@ -16,16 +20,10 @@ public final class ShannonEntropyFactory
 {
 
   /**
-   * Pattern to search for uppercase characters.  (As suggested by NIST SP-800-63-1 a password has
-   * composition rules if it checks for anything other than lowercase letter password).
+   * Number of character characteristics rule to enforce to consider a password having
+   * composition check.
    */
-  private static final Pattern UPPERCASE_PATTERN = Pattern.compile("[A-Z]");
-
-  /**
-   * Pattern to search for non alphabetic characters. (As suggested by NIST SP-800-63-1 a password has
-   * composition rules if it checks for a rule that requires both upper case and non-alphabetic characters).
-   */
-  private static final Pattern NONALPHABETIC_PATTERN = Pattern.compile("[^a-zA-Z]");
+  private static final int COMPOSITION_CHARACTERISTICS_REQUIREMENT = 4;
 
   /**
    * Private constructor for factory class.
@@ -49,9 +47,27 @@ public final class ShannonEntropyFactory
     final boolean dictionaryCheck = passwordRules.stream()
             .filter(rule -> AbstractDictionaryRule.class.isAssignableFrom(rule.getClass()) &&
                     ((AbstractDictionaryRule) rule).getDictionary().size() > 0).count() > 0;
-    final boolean compositionCheck = UPPERCASE_PATTERN
-            .matcher(passwordData.getPassword()).find() &&
-            NONALPHABETIC_PATTERN.matcher(passwordData.getPassword()).find();
+    final boolean compositionCheck = hasComposition(passwordData);
     return new ShannonEntropy(dictionaryCheck, compositionCheck, passwordData.getPassword().length());
+  }
+
+  /**
+   * Checks whether a given passwordData has composition. (As suggested by NIST SP-800-63-1)
+   *
+   * @param passwordData Password to check for composition
+   * @return true if valid, false otherwise
+   */
+  protected static boolean hasComposition(final PasswordData passwordData)
+  {
+    final CharacterCharacteristicsRule compositionRule = new CharacterCharacteristicsRule();
+    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.Digit, 1));
+    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.Special, 1));
+    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.UpperCase, 1));
+    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.LowerCase, 1));
+    compositionRule.setNumberOfCharacteristics(COMPOSITION_CHARACTERISTICS_REQUIREMENT);
+    final List<Rule> rules = new ArrayList<>();
+    rules.add(compositionRule);
+    final PasswordValidator compositionValidator = new PasswordValidator(rules);
+    return compositionValidator.validate(passwordData).isValid();
   }
 }

--- a/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
@@ -19,11 +19,9 @@ import org.passay.Rule;
 public final class ShannonEntropyFactory
 {
 
-  /**
-   * Number of character characteristics rule to enforce to consider a password having
-   * composition check.
-   */
+  /** Number of character characteristics rules to enforce for a password to have composition. */
   private static final int COMPOSITION_CHARACTERISTICS_REQUIREMENT = 4;
+
 
   /**
    * Private constructor for factory class.
@@ -44,17 +42,19 @@ public final class ShannonEntropyFactory
     if (!passwordData.getOrigin().equals(PasswordData.Origin.User)) {
       throw new IllegalArgumentException("Password data must have an origin of " + PasswordData.Origin.User);
     }
-    final boolean dictionaryCheck = passwordRules.stream()
-            .filter(rule -> AbstractDictionaryRule.class.isAssignableFrom(rule.getClass()) &&
-                    ((AbstractDictionaryRule) rule).getDictionary().size() > 0).count() > 0;
+    final boolean dictionaryCheck = passwordRules.stream().filter(
+      rule -> AbstractDictionaryRule.class.isAssignableFrom(
+        rule.getClass()) && ((AbstractDictionaryRule) rule).getDictionary().size() > 0).count() > 0;
     final boolean compositionCheck = hasComposition(passwordData);
     return new ShannonEntropy(dictionaryCheck, compositionCheck, passwordData.getPassword().length());
   }
+
 
   /**
    * Checks whether a given passwordData has composition. (As suggested by NIST SP-800-63-1)
    *
    * @param passwordData Password to check for composition
+   *
    * @return true if valid, false otherwise
    */
   protected static boolean hasComposition(final PasswordData passwordData)

--- a/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
@@ -2,11 +2,8 @@
 package org.passay.entropy;
 
 import java.util.List;
+import java.util.regex.Pattern;
 import org.passay.AbstractDictionaryRule;
-import org.passay.AllowedCharacterRule;
-import org.passay.CharacterCharacteristicsRule;
-import org.passay.CharacterRule;
-import org.passay.EnglishCharacterData;
 import org.passay.PasswordData;
 import org.passay.Rule;
 
@@ -18,6 +15,17 @@ import org.passay.Rule;
 public final class ShannonEntropyFactory
 {
 
+  /**
+   * Pattern to search for uppercase characters.  (As suggested by NIST SP-800-63-1 a password has
+   * composition rules if it checks for anything other than lowercase letter password).
+   */
+  private static final Pattern UPPERCASE_PATTERN = Pattern.compile("[A-Z]");
+
+  /**
+   * Pattern to search for non alphabetic characters. (As suggested by NIST SP-800-63-1 a password has
+   * composition rules if it checks for a rule that requires both upper case and non-alphabetic characters).
+   */
+  private static final Pattern NONALPHABETIC_PATTERN = Pattern.compile("[^a-zA-Z]");
 
   /**
    * Private constructor for factory class.
@@ -38,57 +46,12 @@ public final class ShannonEntropyFactory
     if (!passwordData.getOrigin().equals(PasswordData.Origin.User)) {
       throw new IllegalArgumentException("Password data must have an origin of " + PasswordData.Origin.User);
     }
-    boolean dictionaryCheck = false;
-    boolean compositionCheck = false;
-    for (Rule rule : passwordRules) {
-      if (!compositionCheck) {
-        if (rule instanceof CharacterCharacteristicsRule) {
-          final CharacterCharacteristicsRule characteristicRule = (CharacterCharacteristicsRule) rule;
-          for (CharacterRule r : characteristicRule.getRules()) {
-            compositionCheck = hasComposition(r, r.getValidCharacters(), passwordData);
-            if (compositionCheck) {
-              break;
-            }
-          }
-        } else if (rule instanceof CharacterRule) {
-          final CharacterRule characterRule = (CharacterRule) rule;
-          compositionCheck = hasComposition(characterRule, characterRule.getValidCharacters(), passwordData);
-        } else if (rule instanceof AllowedCharacterRule) {
-          final AllowedCharacterRule allowedCharacterRule = (AllowedCharacterRule) rule;
-          compositionCheck = hasComposition(
-            rule,
-            String.valueOf(allowedCharacterRule.getAllowedCharacters()),
-            passwordData);
-        }
-      }
-      if (AbstractDictionaryRule.class.isAssignableFrom(rule.getClass())) {
-        dictionaryCheck = true;
-      }
-    }
+    final boolean dictionaryCheck = passwordRules.stream()
+            .filter(rule -> AbstractDictionaryRule.class.isAssignableFrom(rule.getClass()) &&
+                    ((AbstractDictionaryRule) rule).getDictionary().size() > 0).count() > 0;
+    final boolean compositionCheck = UPPERCASE_PATTERN
+            .matcher(passwordData.getPassword()).find() &&
+            NONALPHABETIC_PATTERN.matcher(passwordData.getPassword()).find();
     return new ShannonEntropy(dictionaryCheck, compositionCheck, passwordData.getPassword().length());
-  }
-
-
-  /**
-   * Determine if the supplied rule and characters has composition. (As defined by NIST SP-800-63-1 a password has
-   * composition rules if it checks for anything other than lowercase letter password).
-   *
-   * @param  rule  to validate for the matching composition rule
-   * @param  characters  to check for composition
-   * @param  passwordData  with the contents of the password.
-   *
-   * @return  whether the supplied rule has the correct composition
-   */
-  private static boolean hasComposition(final Rule rule, final String characters, final PasswordData passwordData)
-  {
-    if (characters != null) {
-      for (char c : characters.toCharArray()) {
-        if (EnglishCharacterData.LowerCase.getCharacters().indexOf(c) == -1 && rule.validate(passwordData).isValid()) {
-          //found at least 1 non-lowercase character in CharacterRule
-          return true;
-        }
-      }
-    }
-    return false;
   }
 }

--- a/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
@@ -22,6 +22,20 @@ public final class ShannonEntropyFactory
   /** Number of character characteristics rules to enforce for a password to have composition. */
   private static final int COMPOSITION_CHARACTERISTICS_REQUIREMENT = 4;
 
+  /** Rule which defines whether a password has composition. */
+  private static final CharacterCharacteristicsRule COMPOSITION_RULE;
+
+
+  /** Initialize the composition rule. */
+  static {
+    COMPOSITION_RULE = new CharacterCharacteristicsRule();
+    COMPOSITION_RULE.getRules().add(new CharacterRule(EnglishCharacterData.Digit, 1));
+    COMPOSITION_RULE.getRules().add(new CharacterRule(EnglishCharacterData.Special, 1));
+    COMPOSITION_RULE.getRules().add(new CharacterRule(EnglishCharacterData.UpperCase, 1));
+    COMPOSITION_RULE.getRules().add(new CharacterRule(EnglishCharacterData.LowerCase, 1));
+    COMPOSITION_RULE.setNumberOfCharacteristics(COMPOSITION_CHARACTERISTICS_REQUIREMENT);
+  }
+
 
   /**
    * Private constructor for factory class.
@@ -51,22 +65,16 @@ public final class ShannonEntropyFactory
 
 
   /**
-   * Checks whether a given passwordData has composition. (As suggested by NIST SP-800-63-1)
+   * Checks whether the supplied passwordData has composition. (As suggested by NIST SP-800-63-1)
    *
-   * @param passwordData Password to check for composition
+   * @param  passwordData  to check for composition
    *
-   * @return true if valid, false otherwise
+   * @return  true if valid, false otherwise
    */
   protected static boolean hasComposition(final PasswordData passwordData)
   {
-    final CharacterCharacteristicsRule compositionRule = new CharacterCharacteristicsRule();
-    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.Digit, 1));
-    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.Special, 1));
-    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.UpperCase, 1));
-    compositionRule.getRules().add(new CharacterRule(EnglishCharacterData.LowerCase, 1));
-    compositionRule.setNumberOfCharacteristics(COMPOSITION_CHARACTERISTICS_REQUIREMENT);
     final List<Rule> rules = new ArrayList<>();
-    rules.add(compositionRule);
+    rules.add(COMPOSITION_RULE);
     final PasswordValidator compositionValidator = new PasswordValidator(rules);
     return compositionValidator.validate(passwordData).isValid();
   }

--- a/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/ShannonEntropyFactory.java
@@ -71,7 +71,7 @@ public final class ShannonEntropyFactory
    *
    * @return  true if valid, false otherwise
    */
-  protected static boolean hasComposition(final PasswordData passwordData)
+  private static boolean hasComposition(final PasswordData passwordData)
   {
     final List<Rule> rules = new ArrayList<>();
     rules.add(COMPOSITION_RULE);

--- a/src/test/java/org/passay/PasswordValidatorTest.java
+++ b/src/test/java/org/passay/PasswordValidatorTest.java
@@ -157,13 +157,13 @@ public class PasswordValidatorTest extends AbstractRuleTest
      */
 
     final PasswordData length5AllLowercasePassword = new PasswordData("hello");
-    final PasswordData length5CompositionPassword = new PasswordData("heL!o");
+    final PasswordData length5CompositionPassword = new PasswordData("h3L!o");
 
     final PasswordData length10AllLowercasePassword = new PasswordData("hellohello");
-    final PasswordData length10CompositionPassword = new PasswordData("helLohell0");
+    final PasswordData length10CompositionPassword = new PasswordData("h3!Lohell0");
 
     final PasswordData length22AllLowercasePassword = new PasswordData("hellohellohellohellooo");
-    final PasswordData length22CompositionPassword = new PasswordData("helloHellohellohello!!");
+    final PasswordData length22CompositionPassword = new PasswordData("he1loHellohellohello!!");
 
     //Test for no character based rules.
     final List<Rule> l = new ArrayList<>();

--- a/src/test/java/org/passay/PasswordValidatorTest.java
+++ b/src/test/java/org/passay/PasswordValidatorTest.java
@@ -157,18 +157,17 @@ public class PasswordValidatorTest extends AbstractRuleTest
      */
 
     final PasswordData length5AllLowercasePassword = new PasswordData("hello");
-    final PasswordData length5CompositionPassword = new PasswordData("heLlo");
+    final PasswordData length5CompositionPassword = new PasswordData("heL!o");
 
     final PasswordData length10AllLowercasePassword = new PasswordData("hellohello");
-    final PasswordData length10CompositionPassword = new PasswordData("hellohell0");
+    final PasswordData length10CompositionPassword = new PasswordData("helLohell0");
 
     final PasswordData length22AllLowercasePassword = new PasswordData("hellohellohellohellooo");
-    final PasswordData length22CompositionPassword = new PasswordData("hellohellohellohello!!");
+    final PasswordData length22CompositionPassword = new PasswordData("helloHellohellohello!!");
 
     //Test for no character based rules.
     final List<Rule> l = new ArrayList<>();
     final PasswordValidator pv = new PasswordValidator(l);
-    l.add(new LengthRule(8, 16));
 
     try {
       pv.estimateEntropy(new PasswordData("heLlo", PasswordData.Origin.Generated));
@@ -178,14 +177,6 @@ public class PasswordValidatorTest extends AbstractRuleTest
     }
 
     //User Password Origin Tests:
-
-    final CharacterCharacteristicsRule ccRule = new CharacterCharacteristicsRule();
-    ccRule.getRules().add(new CharacterRule(EnglishCharacterData.Digit, 1));
-    ccRule.getRules().add(new CharacterRule(EnglishCharacterData.Special, 1));
-    ccRule.getRules().add(new CharacterRule(EnglishCharacterData.UpperCase, 1));
-    ccRule.getRules().add(new CharacterRule(EnglishCharacterData.LowerCase, 1));
-    ccRule.setNumberOfCharacteristics(3);
-    l.add(ccRule);
 
     //Length 5
     AssertJUnit.assertEquals(12.0, pv.estimateEntropy(length5AllLowercasePassword));
@@ -200,7 +191,13 @@ public class PasswordValidatorTest extends AbstractRuleTest
     //Length 22 + Composition
     AssertJUnit.assertEquals(44.0, pv.estimateEntropy(length22CompositionPassword));
 
-    //Fully loaded validator tests:
+    //Empty dictionary check
+    l.add(new DictionarySubstringRule(new WordListDictionary(new ArrayWordList(new String[]{}))));
+
+    //Test Length 10 + Composition + Empty Dictionary
+    AssertJUnit.assertEquals(27.0, pv.estimateEntropy(length10CompositionPassword));
+    //Test Length 10 + Empty Dictionary
+    AssertJUnit.assertEquals(21.0, pv.estimateEntropy(length10AllLowercasePassword));
 
     //Test Length 5 + Composition + Dictionary
     AssertJUnit.assertEquals(20.0, validator.estimateEntropy(length5CompositionPassword));
@@ -209,24 +206,9 @@ public class PasswordValidatorTest extends AbstractRuleTest
     //Test Length 22 + Composition + Dictionary
     AssertJUnit.assertEquals(44.0, validator.estimateEntropy(length22CompositionPassword));
 
-    //AllowedCharacterRule rule test
-    final List<Rule> al = new ArrayList<>();
-    final PasswordValidator pvAl = new PasswordValidator(al);
-    final AllowedCharacterRule allowedRule = new AllowedCharacterRule(
-      new char[]{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'L', '0', '!', });
-    al.add(allowedRule);
-
-    //Length 5 Composition
-    AssertJUnit.assertEquals(15.0, pvAl.estimateEntropy(length5CompositionPassword));
-    //Length 10 Composition
-    AssertJUnit.assertEquals(27.0, pvAl.estimateEntropy(length10CompositionPassword));
-    //Length 22 Composition
-    AssertJUnit.assertEquals(44.0, pvAl.estimateEntropy(length22CompositionPassword));
-
     //Generated Password Origin Tests:
 
-    //182 total unique characters from given CharacterRules
+    //182 total unique characters from given CharacterRules in validator
     length5CompositionPassword.setOrigin(PasswordData.Origin.Generated);
     length10CompositionPassword.setOrigin(PasswordData.Origin.Generated);
     length22CompositionPassword.setOrigin(PasswordData.Origin.Generated);
@@ -243,6 +225,12 @@ public class PasswordValidatorTest extends AbstractRuleTest
       validator.estimateEntropy(length22CompositionPassword));
 
     //Random generated password test with AllowedCharacterRule
+    final List<Rule> al = new ArrayList<>();
+    final PasswordValidator pvAl = new PasswordValidator(al);
+    final AllowedCharacterRule allowedRule = new AllowedCharacterRule(
+      new char[]{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'L', '0', '!', });
+    al.add(allowedRule);
     AssertJUnit.assertEquals(
       new RandomPasswordEntropy(allowedRule.getAllowedCharacters().length,
               length5CompositionPassword.getPassword().length()).estimate(),


### PR DESCRIPTION
I've added a couple minor changes:

- Dictionary should not be instantiated with a null.
- Dictionary interface should return its size.

Reason for those changes was to ensure that we don't flag a Shannon entropy estimate with a supplied empty dictionary.

PS: I love a resolution where there are more deletions than additions :+1: 