### PR TITLE
Add MemmoryMappedFileWordList.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/test/resources/newlines.* -crlf

--- a/src/main/checkstyle/checks.xml
+++ b/src/main/checkstyle/checks.xml
@@ -153,7 +153,9 @@
       <property name="classes" value="java.lang.Boolean"/>
     </module>
     <module name="InnerAssignment"/>
-    <module name="MagicNumber"/>
+    <module name="MagicNumber">
+      <property name="ignoreNumbers" value="100"/>
+    </module>
     <module name="MissingSwitchDefault"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>

--- a/src/main/checkstyle/checks.xml
+++ b/src/main/checkstyle/checks.xml
@@ -154,7 +154,7 @@
     </module>
     <module name="InnerAssignment"/>
     <module name="MagicNumber">
-      <property name="ignoreNumbers" value="100"/>
+      <property name="ignoreNumbers" value="-1,0,1,2,100"/>
     </module>
     <module name="MissingSwitchDefault"/>
     <module name="SimplifyBooleanExpression"/>

--- a/src/main/java/org/passay/dictionary/AbstractFileWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractFileWordList.java
@@ -19,7 +19,7 @@ public abstract class AbstractFileWordList extends AbstractWordList
   /** file containing words. */
   protected final RandomAccessFile file;
 
-  /** number of lines in the file. */
+  /** number of words in the file. */
   protected int size;
 
   /** cache of indexes to file positions. */
@@ -27,6 +27,9 @@ public abstract class AbstractFileWordList extends AbstractWordList
   // uses the firstKey and floorKey implementations
   protected TreeMap<Integer, Long> cache = new TreeMap<>();
   // CheckStyle:IllegalType ON
+
+  /** Synchronization lock. */
+  private final Object lock = new Object();
 
 
   /**
@@ -58,7 +61,11 @@ public abstract class AbstractFileWordList extends AbstractWordList
   public String get(final int index)
   {
     checkRange(index);
-    return readFile(index);
+    try {
+      return readWord(index);
+    } catch (IOException e) {
+      throw new RuntimeException("Error reading from file backing word list", e);
+    }
   }
 
 
@@ -96,13 +103,108 @@ public abstract class AbstractFileWordList extends AbstractWordList
 
 
   /**
-   * Reads the file line by line and returns the word at the supplied index.
+   * Reads words from the backing file to initialize the word list.
    *
-   * @param  index  to read word at
+   * @param  cachePercent  Percent of file in bytes to use for cache.
+   *
+   * @throws  IOException  on I/O errors reading file data.
+   */
+  protected void initialize(final int cachePercent) throws IOException
+  {
+    final long fileBytes = file.length();
+    final long cacheSize = (fileBytes / 100) * cachePercent;
+    final long cacheModulus = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
+
+    FileWord a;
+    FileWord b = null;
+    synchronized (lock) {
+      seek(0);
+      while ((a = nextWord()) != null) {
+        if (b != null && comparator.compare(a.word, b.word) < 0) {
+          throw new IllegalArgumentException("File is not sorted correctly for this comparator");
+        }
+        b = a;
+        if (cacheSize > 0 && size % cacheModulus == 0) {
+          cache.put(size, a.offset);
+        }
+        size++;
+      }
+    }
+  }
+
+
+  /**
+   * Reads the word from the file at the given index of the word list.
+   *
+   * @param  index  ith word in the word list
    *
    * @return  word at the supplied index
    *
-   * @throws  IllegalStateException  if an error occurs reading the supplied file
+   * @throws  IOException  on I/O errors
    */
-  protected abstract String readFile(final int index);
+  protected String readWord(final int index) throws IOException
+  {
+    int i = 0;
+    if (!cache.isEmpty() && cache.firstKey() <= index) {
+      i = cache.floorKey(index);
+    }
+    final long pos = i > 0 ? cache.get(i) : 0L;
+    FileWord w;
+    synchronized (lock) {
+      seek(pos);
+      do {
+        w = nextWord();
+      } while (i++ < index && w != null);
+      return w != null ? w.word : null;
+    }
+  }
+
+
+  /**
+   * Positions the read head of the backing file at the given byte offset.
+   *
+   * @param offset byte offset into file.
+   *
+   * @throws  IOException  on I/O errors seeking.
+   */
+  protected abstract void seek(long offset) throws IOException;
+
+
+  /**
+   * Reads the next word from the current position in the backing file.
+   *
+   * @return  Data structure containing word and byte offset into file where word begins.
+
+   * @throws  IOException  on I/O errors reading file data.
+   */
+  protected abstract FileWord nextWord() throws IOException;
+
+
+  /**
+   * Data structure containing word and byte offset into file where word begins in backing file.
+   */
+  static class FileWord
+  {
+
+    // CheckStyle:VisibilityModifier OFF
+    /** Word read from backing file. */
+    String word;
+
+    /** Byte offset into file where word begins. */
+    long offset;
+    // CheckStyle:VisibilityModifier OFF
+
+
+    /**
+     * Creates a new instance with a word and offset.
+     *
+     * @param  s  word.
+     * @param  position  byte offset into file.
+     */
+    FileWord(final String s, final long position)
+    {
+      word = s;
+      offset = position;
+    }
+  }
 }

--- a/src/main/java/org/passay/dictionary/AbstractFileWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractFileWordList.java
@@ -1,0 +1,111 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.dictionary;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.TreeMap;
+
+/**
+ * Common implementation for file based word lists.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractFileWordList extends AbstractWordList
+{
+
+  /** default cache size. */
+  public static final int DEFAULT_CACHE_SIZE = 5;
+
+  /** 100 percent. */
+  protected static final int HUNDRED_PERCENT = 100;
+
+  /** file containing words. */
+  protected final RandomAccessFile file;
+
+  /** number of lines in the file. */
+  protected int size;
+
+  /** cache of indexes to file positions. */
+  // CheckStyle:IllegalType OFF
+  // uses the firstKey and floorKey implementations
+  protected TreeMap<Integer, Long> cache = new TreeMap<>();
+  // CheckStyle:IllegalType ON
+
+
+  /**
+   * Creates a new abstract file word list from the supplied file.
+   *
+   * @param  raf  File containing words, one per line.
+   * @param  caseSensitive  Set to true to create case-sensitive word list, false otherwise.
+   * @param  cachePercent  Percent (0-100) of file to cache in memory for improved read performance.
+   *
+   * @throws  IllegalArgumentException  if cache percent is out of range.
+   * @throws  IOException  if an error occurs reading the supplied file
+   */
+  public AbstractFileWordList(final RandomAccessFile raf, final boolean caseSensitive, final int cachePercent)
+    throws IOException
+  {
+    if (cachePercent < 0 || cachePercent > HUNDRED_PERCENT) {
+      throw new IllegalArgumentException("cachePercent must be between 0 and 100 inclusive");
+    }
+    file = raf;
+    if (caseSensitive) {
+      comparator = WordLists.CASE_SENSITIVE_COMPARATOR;
+    } else {
+      comparator = WordLists.CASE_INSENSITIVE_COMPARATOR;
+    }
+  }
+
+
+  @Override
+  public String get(final int index)
+  {
+    checkRange(index);
+    return readFile(index);
+  }
+
+
+  @Override
+  public int size()
+  {
+    return size;
+  }
+
+
+  /**
+   * Returns the file backing this list.
+   *
+   * @return  random access file that is backing this list
+   */
+  public RandomAccessFile getFile()
+  {
+    return file;
+  }
+
+
+  /**
+   * Closes the underlying file and make the cache available for garbage collection.
+   *
+   * @throws  IOException  if an error occurs closing the file
+   */
+  public void close()
+    throws IOException
+  {
+    synchronized (file) {
+      file.close();
+    }
+    cache = null;
+  }
+
+
+  /**
+   * Reads the file line by line and returns the word at the supplied index.
+   *
+   * @param  index  to read word at
+   *
+   * @return  word at the supplied index
+   *
+   * @throws  IllegalStateException  if an error occurs reading the supplied file
+   */
+  protected abstract String readFile(final int index);
+}

--- a/src/main/java/org/passay/dictionary/AbstractFileWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractFileWordList.java
@@ -16,9 +16,6 @@ public abstract class AbstractFileWordList extends AbstractWordList
   /** default cache size. */
   public static final int DEFAULT_CACHE_SIZE = 5;
 
-  /** 100 percent. */
-  protected static final int HUNDRED_PERCENT = 100;
-
   /** file containing words. */
   protected final RandomAccessFile file;
 
@@ -45,7 +42,7 @@ public abstract class AbstractFileWordList extends AbstractWordList
   public AbstractFileWordList(final RandomAccessFile raf, final boolean caseSensitive, final int cachePercent)
     throws IOException
   {
-    if (cachePercent < 0 || cachePercent > HUNDRED_PERCENT) {
+    if (cachePercent < 0 || cachePercent > 100) {
       throw new IllegalArgumentException("cachePercent must be between 0 and 100 inclusive");
     }
     file = raf;

--- a/src/main/java/org/passay/dictionary/FileWordList.java
+++ b/src/main/java/org/passay/dictionary/FileWordList.java
@@ -79,7 +79,7 @@ public class FileWordList extends AbstractFileWordList
 
     final long fileBytes = file.length();
     final long cacheSize = (fileBytes / 100) * cachePercent;
-    final long cacheOffset = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
+    final long cacheModulus = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
 
     String a;
     String b = null;
@@ -89,7 +89,7 @@ public class FileWordList extends AbstractFileWordList
       }
       b = a;
 
-      if (cacheSize > 0 && size % cacheOffset == 0) {
+      if (cacheSize > 0 && size % cacheModulus == 0) {
         cache.put(size, pos);
       }
       pos = file.getFilePointer();

--- a/src/main/java/org/passay/dictionary/FileWordList.java
+++ b/src/main/java/org/passay/dictionary/FileWordList.java
@@ -78,7 +78,7 @@ public class FileWordList extends AbstractFileWordList
     file.seek(pos);
 
     final long fileBytes = file.length();
-    final long cacheSize = (fileBytes / HUNDRED_PERCENT) * cachePercent;
+    final long cacheSize = (fileBytes / 100) * cachePercent;
     final long cacheOffset = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
 
     String a;

--- a/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
+++ b/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
@@ -81,7 +81,7 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
     buffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
 
     final int fileBytes = buffer.capacity();
-    final int cacheSize = (fileBytes / HUNDRED_PERCENT) * cachePercent;
+    final int cacheSize = (fileBytes / 100) * cachePercent;
     final int cacheOffset = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
 
     long pos = 0;

--- a/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
+++ b/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
@@ -82,7 +82,7 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
 
     final int fileBytes = buffer.capacity();
     final int cacheSize = (fileBytes / 100) * cachePercent;
-    final int cacheOffset = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
+    final int cacheModulus = cacheSize == 0 ? fileBytes : cacheSize > fileBytes ? 1 : fileBytes / cacheSize;
 
     long pos = 0;
     String a;
@@ -93,7 +93,7 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
       }
       b = a;
 
-      if (cacheSize > 0 && size % cacheOffset == 0) {
+      if (cacheSize > 0 && size % cacheModulus == 0) {
         cache.put(size, pos);
       }
       pos = buffer.position();

--- a/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
+++ b/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
@@ -87,8 +87,7 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
     long pos = 0;
     String a;
     String b = null;
-    while (buffer.hasRemaining()) {
-      a = readLine(buffer);
+    while ((a = readLine(buffer)) != null) {
       if (b != null && comparator.compare(a, b) < 0) {
         throw new IllegalArgumentException("File is not sorted correctly for this comparator");
       }
@@ -144,33 +143,22 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
    *
    * @param  buffer  to read from
    *
-   * @return  file line
+   * @return  file line or null if end of file has been reached
    */
   private static String readLine(final MappedByteBuffer buffer)
   {
     final StringBuilder line = new StringBuilder();
-    boolean lineFeed = false;
-    boolean carriageReturn = false;
     while (buffer.hasRemaining()) {
       final char c = (char) buffer.get();
-      if (lineFeed) {
-        buffer.position(buffer.position() - 1);
+      if (c == '\n' || c == '\r') {
+        // Ignore leading line termination characters
+        if (line.length() == 0) {
+          continue;
+        }
         break;
       }
-      if (carriageReturn) {
-        if (c != '\n') {
-          buffer.position(buffer.position() - 1);
-          break;
-        }
-      }
-      if (c == '\n') {
-        lineFeed = true;
-      } else if (c == '\r') {
-        carriageReturn = true;
-      } else {
-        line.append(c);
-      }
+      line.append(c);
     }
-    return line.toString();
+    return line.length() > 0 ? line.toString() : null;
   }
 }

--- a/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
+++ b/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
@@ -145,20 +145,34 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
    *
    * @return  file line or null if end of file has been reached
    */
-  private static String readLine(final MappedByteBuffer buffer)
+  protected static String readLine(final MappedByteBuffer buffer)
   {
+    if (!buffer.hasRemaining()) {
+      return null;
+    }
     final StringBuilder line = new StringBuilder();
+    boolean lineFeed = false;
+    boolean carriageReturn = false;
     while (buffer.hasRemaining()) {
       final char c = (char) buffer.get();
-      if (c == '\n' || c == '\r') {
-        // Ignore leading line termination characters
-        if (line.length() == 0) {
-          continue;
-        }
+      if (lineFeed) {
+        buffer.position(buffer.position() - 1);
         break;
       }
-      line.append(c);
+      if (carriageReturn) {
+        if (c != '\n') {
+          buffer.position(buffer.position() - 1);
+          break;
+        }
+      }
+      if (c == '\n') {
+        lineFeed = true;
+      } else if (c == '\r') {
+        carriageReturn = true;
+      } else {
+        line.append(c);
+      }
     }
-    return line.length() > 0 ? line.toString() : null;
+    return line.toString();
   }
 }

--- a/src/test/java/org/passay/dictionary/AbstractWordListTest.java
+++ b/src/test/java/org/passay/dictionary/AbstractWordListTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractWordListTest<T extends WordList>
    */
   @Test(groups = {"wltest"}, dataProvider = "wordLists")
   public void get(final T list)
-      throws Exception
+    throws Exception
   {
     AssertJUnit.assertEquals(26, list.size());
 

--- a/src/test/java/org/passay/dictionary/AbstractWordListTest.java
+++ b/src/test/java/org/passay/dictionary/AbstractWordListTest.java
@@ -8,9 +8,11 @@ import org.testng.annotations.Test;
 /**
  * Common unit tests for {@link WordList} implementations.
  *
+ * @param  <T>  Type of word list under test.
+ *
  * @author  Middleware Services
  */
-public abstract class AbstractWordListTest
+public abstract class AbstractWordListTest<T extends WordList>
 {
 
   /** False contains. */
@@ -23,39 +25,48 @@ public abstract class AbstractWordListTest
   public static final int TRUE_CONTAINS_INDEX = 103;
 
   /** Test list. */
-  protected WordList wordList;
+  protected T wordList;
 
 
   /**
-   * Test for {@link WordList#get(int)}.
+   * Exercises reading words from {@link FileWordList}.
+   *
+   * @param  list  word list to test.
    *
    * @throws  Exception  On test failure.
    */
-  @Test(groups = {"wltest"})
-  public void get()
-    throws Exception
+  @Test(groups = {"wltest"}, dataProvider = "wordLists")
+  public void get(final T list)
+      throws Exception
   {
+    AssertJUnit.assertEquals(26, list.size());
+
     try {
-      wordList.get(-1);
+      list.get(-1);
       AssertJUnit.fail("Should have thrown IndexOutOfBoundsException");
     } catch (IndexOutOfBoundsException e) {
       AssertJUnit.assertEquals(e.getClass(), IndexOutOfBoundsException.class);
     } catch (Exception e) {
       AssertJUnit.fail("Should have thrown IndexOutOfBoundsException, threw " + e.getMessage());
     }
-
+    AssertJUnit.assertEquals("Alpha", list.get(0));
+    AssertJUnit.assertEquals("Bravo", list.get(1));
+    AssertJUnit.assertEquals("Charlie", list.get(2));
+    AssertJUnit.assertEquals("Delta", list.get(3));
+    AssertJUnit.assertEquals("Echo", list.get(4));
+    AssertJUnit.assertEquals("Foxtrot", list.get(5));
+    AssertJUnit.assertEquals("Mike", list.get(12));
+    AssertJUnit.assertEquals("November", list.get(13));
+    AssertJUnit.assertEquals("Yankee", list.get(24));
+    AssertJUnit.assertEquals("Zulu", list.get(25));
     try {
-      wordList.get(282);
+      list.get(26);
       AssertJUnit.fail("Should have thrown IndexOutOfBoundsException");
     } catch (IndexOutOfBoundsException e) {
       AssertJUnit.assertEquals(e.getClass(), IndexOutOfBoundsException.class);
     } catch (Exception e) {
       AssertJUnit.fail("Should have thrown IndexOutOfBoundsException, threw " + e.getMessage());
     }
-
-    AssertJUnit.assertEquals("ABI", wordList.get(0));
-    AssertJUnit.assertEquals("MIPS", wordList.get(107));
-    AssertJUnit.assertEquals("website", wordList.get(281));
   }
 
 

--- a/src/test/java/org/passay/dictionary/ArrayWordListDictionaryPerfTest.java
+++ b/src/test/java/org/passay/dictionary/ArrayWordListDictionaryPerfTest.java
@@ -49,7 +49,7 @@ public class ArrayWordListDictionaryPerfTest extends AbstractDictionaryPerfTest
     throws Exception
   {
     System.out.println(
-      wld.getClass().getSimpleName() + " (" + ArrayWordList.class.getSimpleName() + ") search time: " +
+      wld.getClass().getSimpleName() + " (" + ArrayWordList.class.getSimpleName() + ") total search time: " +
       (wldSearchTime / 1000 / 1000) + "ms");
     System.out.println(
       wld.getClass().getSimpleName() + " (" + ArrayWordList.class.getSimpleName() + ") avg time per search: " +

--- a/src/test/java/org/passay/dictionary/ArrayWordListTest.java
+++ b/src/test/java/org/passay/dictionary/ArrayWordListTest.java
@@ -51,7 +51,7 @@ public class ArrayWordListTest extends AbstractWordListTest
    */
   @DataProvider(name = "wordLists")
   public Object[][] getWordLists()
-      throws IOException
+    throws IOException
   {
     return new Object[][] {
       new Object[] {wordList},

--- a/src/test/java/org/passay/dictionary/ArrayWordListTest.java
+++ b/src/test/java/org/passay/dictionary/ArrayWordListTest.java
@@ -2,10 +2,12 @@
 package org.passay.dictionary;
 
 import java.io.FileReader;
+import java.io.IOException;
 import java.util.Arrays;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -23,7 +25,7 @@ public class ArrayWordListTest extends AbstractWordListTest
    *
    * @throws  Exception  On test failure.
    */
-  @Parameters("fbsdFileSorted")
+  @Parameters("newLinesUnix")
   @BeforeClass(groups = {"wltest"})
   public void createWordList(final String file)
     throws Exception
@@ -40,10 +42,25 @@ public class ArrayWordListTest extends AbstractWordListTest
     wordList = null;
   }
 
+  /**
+   * Create test parameters.
+   *
+   * @return  Array of MemoryMappedFileWordListTest.
+   *
+   * @throws IOException  on file I/O errors.
+   */
+  @DataProvider(name = "wordLists")
+  public Object[][] getWordLists()
+      throws IOException
+  {
+    return new Object[][] {
+      new Object[] {wordList},
+    };
+  }
 
   /** @throws  Exception  On test failure. */
   @Test(groups = {"wltest"})
-  public void construt()
+  public void construct()
     throws Exception
   {
     try {

--- a/src/test/java/org/passay/dictionary/FileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/FileWordListTest.java
@@ -1,10 +1,12 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.dictionary;
 
+import java.io.IOException;
 import java.io.RandomAccessFile;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -13,21 +15,34 @@ import org.testng.annotations.Test;
  *
  * @author  Middleware Services
  */
-public class FileWordListTest extends AbstractWordListTest
+public class FileWordListTest extends AbstractWordListTest<FileWordList>
 {
+  /** Word list backed by file with Unix line endings. */
+  private FileWordList unixWordList;
 
+  /** Word list backed by file with Mac line endings. */
+  private FileWordList macWordList;
+
+  /** Word list backed by file with DOS line endings. */
+  private FileWordList dosWordList;
 
   /**
-   * @param  file  dictionary to load.
+   * @param  file  path to word list file
+   * @param  unixFile  path to word list file with unix line endings
+   * @param  macFile  path to word list file with mac line endings
+   * @param  dosFile  path to word list file with dos line endings
    *
    * @throws  Exception  On test failure.
    */
-  @Parameters("fbsdFileSorted")
+  @Parameters({ "fbsdFileSorted", "newLinesUnix", "newLinesMac", "newLinesDos" })
   @BeforeClass(groups = {"wltest"})
-  public void createWordList(final String file)
+  public void createWordLists(final String file, final String unixFile, final String macFile, final String dosFile)
     throws Exception
   {
     wordList = new FileWordList(new RandomAccessFile(file, "r"));
+    unixWordList = new FileWordList(new RandomAccessFile(unixFile, "r"), false, 0);
+    macWordList = new FileWordList(new RandomAccessFile(macFile, "r"), false, 50);
+    dosWordList = new FileWordList(new RandomAccessFile(dosFile, "r"), true, 100);
   }
 
 
@@ -38,11 +53,33 @@ public class FileWordListTest extends AbstractWordListTest
    */
   @AfterClass(groups = {"wltest"})
   public void closeWordList()
-    throws Exception
+      throws Exception
   {
-    AssertJUnit.assertTrue(((FileWordList) wordList).getFile().getFD().valid());
-    ((FileWordList) wordList).close();
-    AssertJUnit.assertFalse(((FileWordList) wordList).getFile().getFD().valid());
+    final FileWordList[] lists = {wordList, unixWordList, macWordList, dosWordList};
+    for (FileWordList list : lists) {
+      AssertJUnit.assertTrue(list.getFile().getFD().valid());
+      list.close();
+      AssertJUnit.assertFalse(list.getFile().getFD().valid());
+    }
+  }
+
+
+  /**
+   * Create test parameters.
+   *
+   * @return  Array of MemoryMappedFileWordListTest.
+   *
+   * @throws IOException  on file I/O errors.
+   */
+  @DataProvider(name = "wordLists")
+  public Object[][] getWordLists()
+      throws IOException
+  {
+    return new Object[][] {
+      new Object[] {unixWordList},
+      new Object[] {macWordList},
+      new Object[] {dosWordList},
+    };
   }
 
 

--- a/src/test/java/org/passay/dictionary/FileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/FileWordListTest.java
@@ -54,7 +54,7 @@ public class FileWordListTest extends AbstractWordListTest
    */
   @Parameters({ "fbsdFileSorted", "fbsdFileLowerCaseSorted" })
   @Test(groups = {"wltest"})
-  public void construt(final String file1, final String file2)
+  public void construct(final String file1, final String file2)
     throws Exception
   {
     try {

--- a/src/test/java/org/passay/dictionary/FileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/FileWordListTest.java
@@ -53,7 +53,7 @@ public class FileWordListTest extends AbstractWordListTest<FileWordList>
    */
   @AfterClass(groups = {"wltest"})
   public void closeWordList()
-      throws Exception
+    throws Exception
   {
     final FileWordList[] lists = {wordList, unixWordList, macWordList, dosWordList};
     for (FileWordList list : lists) {
@@ -73,7 +73,7 @@ public class FileWordListTest extends AbstractWordListTest<FileWordList>
    */
   @DataProvider(name = "wordLists")
   public Object[][] getWordLists()
-      throws IOException
+    throws IOException
   {
     return new Object[][] {
       new Object[] {unixWordList},

--- a/src/test/java/org/passay/dictionary/MemoryMappedFileWordListDictionaryPerfTest.java
+++ b/src/test/java/org/passay/dictionary/MemoryMappedFileWordListDictionaryPerfTest.java
@@ -2,6 +2,7 @@
 package org.passay.dictionary;
 
 import java.io.RandomAccessFile;
+
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
@@ -12,7 +13,7 @@ import org.testng.annotations.Test;
  *
  * @author  Middleware Services
  */
-public class FileWordListDictionaryPerfTest extends AbstractDictionaryPerfTest
+public class MemoryMappedFileWordListDictionaryPerfTest extends AbstractDictionaryPerfTest
 {
 
   /** dictionary to test. */
@@ -36,10 +37,11 @@ public class FileWordListDictionaryPerfTest extends AbstractDictionaryPerfTest
     super.initialize(dict1, dict2);
 
     long t = System.currentTimeMillis();
-    wld = new WordListDictionary(new FileWordList(new RandomAccessFile(webFile, "r")));
+    wld = new WordListDictionary(new MemoryMappedFileWordList(new RandomAccessFile(webFile, "r")));
     t = System.currentTimeMillis() - t;
     System.out.println(
-      wld.getClass().getSimpleName() + " (" + FileWordList.class.getSimpleName() + ") time to construct: " + t + "ms");
+      wld.getClass().getSimpleName() + " (" + MemoryMappedFileWordList.class.getSimpleName() +
+          ") time to construct: " + t + "ms");
   }
 
 
@@ -49,11 +51,11 @@ public class FileWordListDictionaryPerfTest extends AbstractDictionaryPerfTest
     throws Exception
   {
     System.out.println(
-      wld.getClass().getSimpleName() + " (" + FileWordList.class.getSimpleName() + ") total search time: " +
-      (wldSearchTime / 1000 / 1000) + "ms");
+      wld.getClass().getSimpleName() + " (" + MemoryMappedFileWordList.class.getSimpleName() +
+          ") total search time: " + (wldSearchTime / 1000 / 1000) + "ms");
     System.out.println(
-      wld.getClass().getSimpleName() + " (" + FileWordList.class.getSimpleName() + ") avg time per search: " +
-      (wldSearchTime / 10000) + "ns");
+      wld.getClass().getSimpleName() + " (" + MemoryMappedFileWordList.class.getSimpleName() +
+          ") avg time per search: " + (wldSearchTime / 10000) + "ns");
     wld = null;
   }
 

--- a/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
@@ -28,6 +28,9 @@ public class MemoryMappedFileWordListTest extends AbstractWordListTest
     throws Exception
   {
     wordList = new MemoryMappedFileWordList(new RandomAccessFile(file, "r"));
+    AssertJUnit.assertEquals(282, wordList.size());
+    AssertJUnit.assertEquals("DVD", wordList.get(42));
+    AssertJUnit.assertEquals("UID", wordList.get(199));
   }
 
 
@@ -54,7 +57,7 @@ public class MemoryMappedFileWordListTest extends AbstractWordListTest
    */
   @Parameters({ "fbsdFileSorted", "fbsdFileLowerCaseSorted" })
   @Test(groups = {"wltest"})
-  public void construt(final String file1, final String file2)
+  public void construct(final String file1, final String file2)
     throws Exception
   {
     try {

--- a/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
@@ -38,7 +38,7 @@ public class MemoryMappedFileWordListTest extends AbstractWordListTest<MemoryMap
   @Parameters({ "fbsdFileSorted", "newLinesUnix", "newLinesMac", "newLinesDos" })
   @BeforeClass(groups = {"wltest"})
   public void createWordLists(final String file, final String unixFile, final String macFile, final String dosFile)
-      throws Exception
+    throws Exception
   {
     wordList = new MemoryMappedFileWordList(new RandomAccessFile(file, "r"));
     unixWordList = new MemoryMappedFileWordList(new RandomAccessFile(unixFile, "r"), false, 0);
@@ -54,7 +54,7 @@ public class MemoryMappedFileWordListTest extends AbstractWordListTest<MemoryMap
    */
   @AfterClass(groups = {"wltest"})
   public void closeWordLists()
-      throws Exception
+    throws Exception
   {
     final MemoryMappedFileWordList[] lists = {wordList, unixWordList, macWordList, dosWordList};
     for (MemoryMappedFileWordList list : lists) {
@@ -74,7 +74,7 @@ public class MemoryMappedFileWordListTest extends AbstractWordListTest<MemoryMap
    */
   @DataProvider(name = "wordLists")
   public Object[][] getWordLists()
-      throws IOException
+    throws IOException
   {
     return new Object[][] {
       new Object[] {unixWordList},

--- a/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
+++ b/src/test/java/org/passay/dictionary/MemoryMappedFileWordListTest.java
@@ -1,0 +1,84 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.dictionary;
+
+import java.io.RandomAccessFile;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link MemoryMappedFileWordList}.
+ *
+ * @author  Middleware Services
+ */
+public class MemoryMappedFileWordListTest extends AbstractWordListTest
+{
+
+
+  /**
+   * @param  file  dictionary to load.
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Parameters("fbsdFileSorted")
+  @BeforeClass(groups = {"wltest"})
+  public void createWordList(final String file)
+    throws Exception
+  {
+    wordList = new MemoryMappedFileWordList(new RandomAccessFile(file, "r"));
+  }
+
+
+  /**
+   * Test for {@link MemoryMappedFileWordList#close()}.
+   *
+   * @throws  Exception  On test failure.
+   */
+  @AfterClass(groups = {"wltest"})
+  public void closeWordList()
+    throws Exception
+  {
+    AssertJUnit.assertTrue(((MemoryMappedFileWordList) wordList).getFile().getFD().valid());
+    ((MemoryMappedFileWordList) wordList).close();
+    AssertJUnit.assertFalse(((MemoryMappedFileWordList) wordList).getFile().getFD().valid());
+  }
+
+
+  /**
+   * @param  file1  dictionary to load.
+   * @param  file2  dictionary to load.
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Parameters({ "fbsdFileSorted", "fbsdFileLowerCaseSorted" })
+  @Test(groups = {"wltest"})
+  public void construt(final String file1, final String file2)
+    throws Exception
+  {
+    try {
+      new MemoryMappedFileWordList(new RandomAccessFile(file1, "r"), true, -1);
+      AssertJUnit.fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      AssertJUnit.assertEquals(e.getClass(), IllegalArgumentException.class);
+    } catch (Exception e) {
+      AssertJUnit.fail("Should have thrown IllegalArgumentException, threw " + e.getMessage());
+    }
+
+    try {
+      new MemoryMappedFileWordList(new RandomAccessFile(file1, "r"), true, 101);
+      AssertJUnit.fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      AssertJUnit.assertEquals(e.getClass(), IllegalArgumentException.class);
+    } catch (Exception e) {
+      AssertJUnit.fail("Should have thrown IllegalArgumentException, threw " + e.getMessage());
+    }
+
+    MemoryMappedFileWordList fwl = new MemoryMappedFileWordList(new RandomAccessFile(file1, "r"), true, 0);
+    fwl.close();
+
+    fwl = new MemoryMappedFileWordList(new RandomAccessFile(file2, "r"), false, 0);
+    fwl.close();
+  }
+}

--- a/src/test/resources/newlines.dos
+++ b/src/test/resources/newlines.dos
@@ -1,0 +1,4 @@
+This is the first line
+
+This is the second to last line
+

--- a/src/test/resources/newlines.dos
+++ b/src/test/resources/newlines.dos
@@ -1,4 +1,37 @@
-This is the first line
+Alpha
+Bravo
+Charlie
+Delta
 
-This is the second to last line
+
+
+
+
+Echo
+Foxtrot
+Golf
+Hotel
+India
+Juliet
+Kilo
+Lima
+
+
+Mike
+November
+Oscar
+Papa
+Quebec
+Romeo
+Sierra
+Tango
+
+
+
+Uniform
+Victor
+Whiskey
+X-ray
+Yankee
+Zulu
 

--- a/src/test/resources/newlines.mac
+++ b/src/test/resources/newlines.mac
@@ -1,0 +1,1 @@
+This is the first lineThis is the second to last line

--- a/src/test/resources/newlines.mac
+++ b/src/test/resources/newlines.mac
@@ -1,1 +1,1 @@
-This is the first lineThis is the second to last line
+AlphaBravoCharlieDeltaEchoFoxtrotGolfHotelIndiaJulietKiloLimaMikeNovemberOscarPapaQuebecRomeoSierraTangoUniformVictorWhiskeyX-rayYankeeZulu

--- a/src/test/resources/newlines.unix
+++ b/src/test/resources/newlines.unix
@@ -1,0 +1,4 @@
+This is the first line
+
+This is the second to last line
+

--- a/src/test/resources/newlines.unix
+++ b/src/test/resources/newlines.unix
@@ -1,4 +1,36 @@
-This is the first line
+Alpha
+Bravo
+Charlie
+Delta
 
-This is the second to last line
 
+
+
+
+Echo
+Foxtrot
+Golf
+Hotel
+India
+Juliet
+Kilo
+Lima
+
+
+Mike
+November
+Oscar
+Papa
+Quebec
+Romeo
+Sierra
+Tango
+
+
+
+Uniform
+Victor
+Whiskey
+X-ray
+Yankee
+Zulu

--- a/src/test/testng/testng.xml
+++ b/src/test/testng/testng.xml
@@ -16,6 +16,9 @@
   <parameter name="fbsdFileLowerCase" value="src/test/resources/freebsd.lc"/>
   <parameter name="fbsdFileLowerCaseSorted" value="src/test/resources/freebsd.lc.sort"/>
   <parameter name="eignFile" value="src/test/resources/eign"/>
+  <parameter name="newLinesUnix" value="src/test/resources/newlines.unix"/>
+  <parameter name="newLinesMac" value="src/test/resources/newlines.mac"/>
+  <parameter name="newLinesDos" value="src/test/resources/newlines.dos"/>
 
   <parameter name="partialSearchWord" value=".e.e.e.e"/>
   <parameter name="partialSearchResults" value="Genevese|reserene|teleseme|terebene"/>


### PR DESCRIPTION
Improve FileWordList by using BufferReader in #readFile.
Change the meaning of cachePercent to apply to file size rather than number of lines.
(It's meaning was never well defined.)
This allows the cache to be built inline while reading the file, removing the need to read the file twice.
This will generally result in larger caches, but users can tune the cache size down if that is an issue.