### PR TITLE
Allow reporting of all failures for these rules.

### DIFF
--- a/src/main/java/org/passay/AllowedCharacterRule.java
+++ b/src/main/java/org/passay/AllowedCharacterRule.java
@@ -2,12 +2,14 @@
 package org.passay;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * Rule for determining if a password contains allowed characters. Validation will fail unless the password contains all
- * of the allowed characters.
+ * Rule for determining if a password contains allowed characters. Validation will fail unless the password contains
+ * only allowed characters.
  *
  * @author  Middleware Services
  */
@@ -16,6 +18,9 @@ public class AllowedCharacterRule implements Rule
 
   /** Error code for allowed character failures. */
   public static final String ERROR_CODE = "ALLOWED_CHAR";
+
+  /** Whether to report all sequence matches or just the first. */
+  protected boolean reportAllFailures;
 
   /** Stores the characters that are allowed. */
   private final char[] allowedCharacters;
@@ -28,12 +33,25 @@ public class AllowedCharacterRule implements Rule
    */
   public AllowedCharacterRule(final char[] c)
   {
+    this(c, true);
+  }
+
+
+  /**
+   * Create a new allowed character rule.
+   *
+   * @param  c  allowed characters
+   * @param  reportAll  whether to report all matches or just the first
+   */
+  public AllowedCharacterRule(final char[] c, final boolean reportAll)
+  {
     if (c.length > 0) {
       allowedCharacters = c;
     } else {
       throw new IllegalArgumentException("allowed characters length must be greater than zero");
     }
     Arrays.sort(allowedCharacters);
+    reportAllFailures = reportAll;
   }
 
 
@@ -52,12 +70,15 @@ public class AllowedCharacterRule implements Rule
   public RuleResult validate(final PasswordData passwordData)
   {
     final RuleResult result = new RuleResult(true);
-
+    final Set<Character> matches = new HashSet<>();
     for (char c : passwordData.getPassword().toCharArray()) {
-      if (Arrays.binarySearch(allowedCharacters, c) < 0) {
+      if (Arrays.binarySearch(allowedCharacters, c) < 0 && !matches.contains(c)) {
         result.setValid(false);
         result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(c)));
-        break;
+        if (!reportAllFailures) {
+          break;
+        }
+        matches.add(c);
       }
     }
     return result;

--- a/src/main/java/org/passay/IllegalSequenceRule.java
+++ b/src/main/java/org/passay/IllegalSequenceRule.java
@@ -28,7 +28,7 @@ public class IllegalSequenceRule implements Rule
   protected boolean wrapSequence;
 
   /** Whether to report all sequence matches or just the first. */
-  protected boolean reportAllFailures = true;
+  protected boolean reportAllFailures;
 
 
   /**

--- a/src/main/java/org/passay/RepeatCharacterRegexRule.java
+++ b/src/main/java/org/passay/RepeatCharacterRegexRule.java
@@ -38,7 +38,19 @@ public class RepeatCharacterRegexRule extends IllegalRegexRule
    */
   public RepeatCharacterRegexRule(final int sl)
   {
-    super(String.format(REPEAT_CHAR_REGEX, sl - 1));
+    this(sl, true);
+  }
+
+
+  /**
+   * Creates a new repeat character regex rule.
+   *
+   * @param  sl  sequence length
+   * @param  reportAll  whether to report all matches or just the first
+   */
+  public RepeatCharacterRegexRule(final int sl, final boolean reportAll)
+  {
+    super(String.format(REPEAT_CHAR_REGEX, sl - 1), reportAll);
     if (sl < MINIMUM_SEQUENCE_LENGTH) {
       throw new IllegalArgumentException(String.format("sequence length must be >= %s", MINIMUM_SEQUENCE_LENGTH));
     }

--- a/src/test/java/org/passay/AllowedCharacterRuleTest.java
+++ b/src/test/java/org/passay/AllowedCharacterRuleTest.java
@@ -11,16 +11,10 @@ import org.testng.annotations.DataProvider;
 public class AllowedCharacterRuleTest extends AbstractRuleTest
 {
 
-  /** Test password. */
-  private static final String VALID_PASS = "boepselwezz";
-
-  /** Test password. */
-  private static final String INVALID_PASS = "gbwersco4kk";
-
-  /** For testing. */
-  private final AllowedCharacterRule rule = new AllowedCharacterRule(
-    new char[]{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-      'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', });
+  /** Allowed characters for testing. */
+  private static final char[] ALLOWED_CHARS = new char[]{
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', };
 
 
   /**
@@ -35,11 +29,31 @@ public class AllowedCharacterRuleTest extends AbstractRuleTest
     return
       new Object[][] {
 
-        {rule, new PasswordData(VALID_PASS), null, },
+        // test valid password
+        {new AllowedCharacterRule(ALLOWED_CHARS), new PasswordData("boepselwezz"), null, },
+        // test invalid password
         {
-          rule,
-          new PasswordData(INVALID_PASS),
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk"),
           codes(AllowedCharacterRule.ERROR_CODE),
+        },
+        // test multiple matches
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk5kk"),
+          codes(AllowedCharacterRule.ERROR_CODE, AllowedCharacterRule.ERROR_CODE),
+        },
+        // test single match
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS, false),
+          new PasswordData("gbwersco4kk5kk"),
+          codes(AllowedCharacterRule.ERROR_CODE),
+        },
+        // test duplicate matches
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk5kk4"),
+          codes(AllowedCharacterRule.ERROR_CODE, AllowedCharacterRule.ERROR_CODE),
         },
       };
   }
@@ -57,9 +71,28 @@ public class AllowedCharacterRuleTest extends AbstractRuleTest
     return
       new Object[][] {
         {
-          rule,
-          new PasswordData(INVALID_PASS),
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk"),
           new String[] {String.format("Password contains the illegal character '%s'.", "4"), },
+        },
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk5kk"),
+          new String[] {
+            String.format("Password contains the illegal character '%s'.", "4"),
+            String.format("Password contains the illegal character '%s'.", "5"), },
+        },
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS, false),
+          new PasswordData("gbwersco4kk5kk"),
+          new String[] {String.format("Password contains the illegal character '%s'.", "4"), },
+        },
+        {
+          new AllowedCharacterRule(ALLOWED_CHARS),
+          new PasswordData("gbwersco4kk5kk4"),
+          new String[] {
+            String.format("Password contains the illegal character '%s'.", "4"),
+            String.format("Password contains the illegal character '%s'.", "5"), },
         },
       };
   }

--- a/src/test/java/org/passay/IllegalCharacterRuleTest.java
+++ b/src/test/java/org/passay/IllegalCharacterRuleTest.java
@@ -11,15 +11,6 @@ import org.testng.annotations.DataProvider;
 public class IllegalCharacterRuleTest extends AbstractRuleTest
 {
 
-  /** Test password. */
-  private static final String VALID_PASS = "AycDPdsyz";
-
-  /** Test password. */
-  private static final String INVALID_PASS = "AycD@Pdsyz";
-
-  /** For testing. */
-  private final IllegalCharacterRule rule = new IllegalCharacterRule(new char[] {'@'});
-
 
   /**
    * @return  Test data.
@@ -33,11 +24,31 @@ public class IllegalCharacterRuleTest extends AbstractRuleTest
     return
       new Object[][] {
 
-        {rule, new PasswordData(VALID_PASS), null, },
+        // test valid password
+        {new IllegalCharacterRule(new char[] {'@', '$'}), new PasswordData("AycDPdsyz"), null, },
+        // test invalid password
         {
-          rule,
-          new PasswordData(INVALID_PASS),
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pdsyz"),
           codes(IllegalCharacterRule.ERROR_CODE),
+        },
+        // test multiple matches
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pd$yz"),
+          codes(IllegalCharacterRule.ERROR_CODE, IllegalCharacterRule.ERROR_CODE),
+        },
+        // test single match
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}, false),
+          new PasswordData("AycD@Pd$yz"),
+          codes(IllegalCharacterRule.ERROR_CODE),
+        },
+        // test duplicate matches
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pd$yz@"),
+          codes(IllegalCharacterRule.ERROR_CODE, IllegalCharacterRule.ERROR_CODE),
         },
       };
   }
@@ -55,9 +66,28 @@ public class IllegalCharacterRuleTest extends AbstractRuleTest
     return
       new Object[][] {
         {
-          rule,
-          new PasswordData(INVALID_PASS),
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pdsyz"),
           new String[] {String.format("Password contains the illegal character '%s'.", "@"), },
+        },
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pd$yz"),
+          new String[] {
+            String.format("Password contains the illegal character '%s'.", "@"),
+            String.format("Password contains the illegal character '%s'.", "$"), },
+        },
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}, false),
+          new PasswordData("AycD@Pd$yz"),
+          new String[] {String.format("Password contains the illegal character '%s'.", "@")},
+        },
+        {
+          new IllegalCharacterRule(new char[] {'@', '$'}),
+          new PasswordData("AycD@Pd$yz@"),
+          new String[] {
+            String.format("Password contains the illegal character '%s'.", "@"),
+            String.format("Password contains the illegal character '%s'.", "$"), },
         },
       };
   }

--- a/src/test/java/org/passay/IllegalRegexRuleTest.java
+++ b/src/test/java/org/passay/IllegalRegexRuleTest.java
@@ -41,6 +41,24 @@ public class IllegalRegexRuleTest extends AbstractRuleTest
           new PasswordData("pwUi0248xwK"),
           codes(IllegalRegexRule.ERROR_CODE),
         },
+        // test multiple matches
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d"),
+          new PasswordData("pwUi0248xwK9753"),
+          codes(IllegalRegexRule.ERROR_CODE, IllegalRegexRule.ERROR_CODE),
+        },
+        // test single match
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d", false),
+          new PasswordData("pwUi0248xwK9753"),
+          codes(IllegalRegexRule.ERROR_CODE),
+        },
+        // test duplicate matches
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d"),
+          new PasswordData("pwUi0248xwK9753uu0248"),
+          codes(IllegalRegexRule.ERROR_CODE, IllegalRegexRule.ERROR_CODE),
+        },
       };
   }
 
@@ -60,6 +78,25 @@ public class IllegalRegexRuleTest extends AbstractRuleTest
           new IllegalRegexRule("\\d\\d\\d\\d"),
           new PasswordData("pwUiNh0248"),
           new String[] {String.format("Password matches the illegal pattern '%s'.", "0248"), },
+        },
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d"),
+          new PasswordData("pwUiNh0248xwK9753"),
+          new String[] {
+            String.format("Password matches the illegal pattern '%s'.", "0248"),
+            String.format("Password matches the illegal pattern '%s'.", "9753"), },
+        },
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d", false),
+          new PasswordData("pwUiNh0248xwK9753"),
+          new String[] {String.format("Password matches the illegal pattern '%s'.", "0248"), },
+        },
+        {
+          new IllegalRegexRule("\\d\\d\\d\\d"),
+          new PasswordData("pwUiNh0248xwK9753uu0248"),
+          new String[] {
+            String.format("Password matches the illegal pattern '%s'.", "0248"),
+            String.format("Password matches the illegal pattern '%s'.", "9753"), },
         },
       };
   }

--- a/src/test/java/org/passay/RepeatCharacterRegexRuleTest.java
+++ b/src/test/java/org/passay/RepeatCharacterRegexRuleTest.java
@@ -60,6 +60,24 @@ public class RepeatCharacterRegexRuleTest extends AbstractRuleTest
           new PasswordData("p4vvvvvvv#n65"),
           codes(RepeatCharacterRegexRule.ERROR_CODE),
         },
+        // test multiple matches
+        {
+          new RepeatCharacterRegexRule(),
+          new PasswordData("p4&&&&&#n65FFFFF"),
+          codes(RepeatCharacterRegexRule.ERROR_CODE, RepeatCharacterRegexRule.ERROR_CODE),
+        },
+        // test single match
+        {
+          new RepeatCharacterRegexRule(5, false),
+          new PasswordData("p4&&&&&#n65FFFFF"),
+          codes(RepeatCharacterRegexRule.ERROR_CODE),
+        },
+        // test duplicate matches
+        {
+          new RepeatCharacterRegexRule(),
+          new PasswordData("p4&&&&&#n65FFFFFQr1&&&&&"),
+          codes(RepeatCharacterRegexRule.ERROR_CODE, RepeatCharacterRegexRule.ERROR_CODE),
+        },
       };
   }
 
@@ -79,6 +97,25 @@ public class RepeatCharacterRegexRuleTest extends AbstractRuleTest
           new RepeatCharacterRegexRule(),
           new PasswordData("p4&&&&&#n65"),
           new String[] {String.format("Password matches the illegal pattern '%s'.", "&&&&&"), },
+        },
+        {
+          new RepeatCharacterRegexRule(),
+          new PasswordData("p4&&&&&#n65FFFFF"),
+          new String[] {
+            String.format("Password matches the illegal pattern '%s'.", "&&&&&"),
+            String.format("Password matches the illegal pattern '%s'.", "FFFFF"), },
+        },
+        {
+          new RepeatCharacterRegexRule(5, false),
+          new PasswordData("p4&&&&&#n65FFFFF"),
+          new String[] {String.format("Password matches the illegal pattern '%s'.", "&&&&&"), },
+        },
+        {
+          new RepeatCharacterRegexRule(),
+          new PasswordData("p4&&&&&#n65FFFFFQr1&&&&&"),
+          new String[] {
+            String.format("Password matches the illegal pattern '%s'.", "&&&&&"),
+            String.format("Password matches the illegal pattern '%s'.", "FFFFF"), },
         },
       };
   }


### PR DESCRIPTION
These rules only reported the first failure, provided a switch to control the behavior.
Also implemented a check so duplicate failures are not reported.
Note that this changes the default behavior for these rules.
Also conformed the implementations of AllowedCharacterRule and IllegalCharacterRule, both use a binary search now.