### PR TITLE
Always return only one result for HistoryRule

### DIFF
--- a/src/main/java/org/passay/HistoryRule.java
+++ b/src/main/java/org/passay/HistoryRule.java
@@ -30,7 +30,7 @@ public class HistoryRule implements Rule
     }
 
     final String cleartext = passwordData.getPassword();
-    references.stream().filter(reference -> matches(cleartext, reference)).forEach(reference -> {
+    references.stream().filter(reference -> matches(cleartext, reference)).findAny().ifPresent(reference -> {
       result.setValid(false);
       result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(size)));
     });


### PR DESCRIPTION
If the password history contains multiple entries that the new password matches to, the result contains two identical result details.

In normal situtations (when using password history rule from the beginning) this wouldn't happen. But in case if a password history check is introduced later on, a result could appear multiple times, as many times as the new password matched the history entries.

This change should make the result a bit more opaque.

Thank you for making this library, it's really useful :+1: 