### PR TITLE
Add reportAllFailures switch to history and source

### DIFF
--- a/src/main/java/org/passay/HistoryRule.java
+++ b/src/main/java/org/passay/HistoryRule.java
@@ -17,6 +17,26 @@ public class HistoryRule implements Rule
   /** Error code for history violation. */
   public static final String ERROR_CODE = "HISTORY_VIOLATION";
 
+  /** Whether to report all history matches or just the first. */
+  protected boolean reportAllFailures;
+
+
+  /**
+   * Creates a new history rule.
+   */
+  public HistoryRule() {}
+
+
+  /**
+   * Creates a new history rule.
+   *
+   * @param  reportAll  whether to report all matches or just the first
+   */
+  public HistoryRule(final boolean reportAll)
+  {
+    reportAllFailures = reportAll;
+  }
+
 
   @Override
   public RuleResult validate(final PasswordData passwordData)
@@ -30,10 +50,17 @@ public class HistoryRule implements Rule
     }
 
     final String cleartext = passwordData.getPassword();
-    references.stream().filter(reference -> matches(cleartext, reference)).forEach(reference -> {
-      result.setValid(false);
-      result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(size)));
-    });
+    if (reportAllFailures) {
+      references.stream().filter(reference -> matches(cleartext, reference)).forEach(reference -> {
+        result.setValid(false);
+        result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(size)));
+      });
+    } else {
+      references.stream().filter(reference -> matches(cleartext, reference)).findFirst().ifPresent(reference -> {
+        result.setValid(false);
+        result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(size)));
+      });
+    }
     return result;
   }
 

--- a/src/main/java/org/passay/SourceRule.java
+++ b/src/main/java/org/passay/SourceRule.java
@@ -18,6 +18,26 @@ public class SourceRule implements Rule
   /** Error code for regex validation failures. */
   public static final String ERROR_CODE = "SOURCE_VIOLATION";
 
+  /** Whether to report all source matches or just the first. */
+  protected boolean reportAllFailures;
+
+
+  /**
+   * Creates a new source rule.
+   */
+  public SourceRule() {}
+
+
+  /**
+   * Creates a new source rule.
+   *
+   * @param  reportAll  whether to report all matches or just the first
+   */
+  public SourceRule(final boolean reportAll)
+  {
+    reportAllFailures = reportAll;
+  }
+
 
   @Override
   public RuleResult validate(final PasswordData passwordData)
@@ -30,11 +50,19 @@ public class SourceRule implements Rule
     }
 
     final String cleartext = passwordData.getPassword();
-    references.stream().filter(reference -> matches(cleartext, reference)).forEach(reference -> {
-      result.setValid(false);
-      result.getDetails().add(
-        new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(reference.getLabel())));
-    });
+    if (reportAllFailures) {
+      references.stream().filter(reference -> matches(cleartext, reference)).forEach(reference -> {
+        result.setValid(false);
+        result.getDetails().add(
+          new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(reference.getLabel())));
+      });
+    } else {
+      references.stream().filter(reference -> matches(cleartext, reference)).findFirst().ifPresent(reference -> {
+        result.setValid(false);
+        result.getDetails().add(
+          new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(reference.getLabel())));
+      });
+    }
     return result;
   }
 

--- a/src/test/java/org/passay/HistoryRuleTest.java
+++ b/src/test/java/org/passay/HistoryRuleTest.java
@@ -21,6 +21,9 @@ public class HistoryRuleTest extends AbstractRuleTest
   private final HistoryRule rule = new HistoryRule();
 
   /** For testing. */
+  private final HistoryRule ruleReportAll = new HistoryRule(true);
+
+  /** For testing. */
   private final HistoryRule emptyRule = new HistoryRule();
 
 
@@ -31,6 +34,7 @@ public class HistoryRuleTest extends AbstractRuleTest
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r01"));
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r02"));
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r03"));
+    history.add(new PasswordData.HistoricalReference("history", "t3stUs3r02"));
   }
 
 
@@ -63,6 +67,23 @@ public class HistoryRuleTest extends AbstractRuleTest
           codes(HistoryRule.ERROR_CODE),
         },
 
+        {ruleReportAll, TestUtils.newPasswordData("t3stUs3r00", "testuser", null, history), null, },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r01", "testuser", null, history),
+          codes(HistoryRule.ERROR_CODE),
+        },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r02", "testuser", null, history),
+          codes(HistoryRule.ERROR_CODE, HistoryRule.ERROR_CODE),
+        },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r03", "testuser", null, history),
+          codes(HistoryRule.ERROR_CODE),
+        },
+
         {emptyRule, TestUtils.newPasswordData("t3stUs3r00", "testuser"), null, },
         {emptyRule, TestUtils.newPasswordData("t3stUs3r01", "testuser"), null, },
         {emptyRule, TestUtils.newPasswordData("t3stUs3r02", "testuser"), null, },
@@ -86,6 +107,14 @@ public class HistoryRuleTest extends AbstractRuleTest
           rule,
           TestUtils.newPasswordData("t3stUs3r01", "testuser", null, history),
           new String[] {String.format("Password matches one of %s previous passwords.", history.size()), },
+        },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r02", "testuser", null, history),
+          new String[] {
+            String.format("Password matches one of %s previous passwords.", history.size()),
+            String.format("Password matches one of %s previous passwords.", history.size()),
+          },
         },
       };
   }

--- a/src/test/java/org/passay/SourceRuleTest.java
+++ b/src/test/java/org/passay/SourceRuleTest.java
@@ -21,6 +21,9 @@ public class SourceRuleTest extends AbstractRuleTest
   private final SourceRule rule = new SourceRule();
 
   /** For testing. */
+  private final SourceRule ruleReportAll = new SourceRule(true);
+
+  /** For testing. */
   private final SourceRule emptyRule = new SourceRule();
 
 
@@ -29,6 +32,8 @@ public class SourceRuleTest extends AbstractRuleTest
   public void createRules()
   {
     sources.add(new PasswordData.SourceReference("System A", "t3stUs3r04"));
+    sources.add(new PasswordData.SourceReference("System A", "t3stUs3r05"));
+    sources.add(new PasswordData.SourceReference("System A", "t3stUs3r05"));
   }
 
 
@@ -50,9 +55,27 @@ public class SourceRuleTest extends AbstractRuleTest
           TestUtils.newPasswordData("t3stUs3r04", "testuser", null, sources),
           codes(SourceRule.ERROR_CODE),
         },
+        {
+          rule,
+          TestUtils.newPasswordData("t3stUs3r05", "testuser", null, sources),
+          codes(SourceRule.ERROR_CODE),
+        },
+
+        {ruleReportAll, TestUtils.newPasswordData("t3stUs3r01", "testuser", null, sources), null, },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r04", "testuser", null, sources),
+          codes(SourceRule.ERROR_CODE),
+        },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r05", "testuser", null, sources),
+          codes(SourceRule.ERROR_CODE, SourceRule.ERROR_CODE),
+        },
 
         {emptyRule, TestUtils.newPasswordData("t3stUs3r01", "testuser"), null, },
         {emptyRule, TestUtils.newPasswordData("t3stUs3r04", "testuser"), null, },
+        {emptyRule, TestUtils.newPasswordData("t3stUs3r05", "testuser"), null, },
       };
   }
 
@@ -72,6 +95,14 @@ public class SourceRuleTest extends AbstractRuleTest
           rule,
           TestUtils.newPasswordData("t3stUs3r04", "testuser", null, sources),
           new String[] {String.format("Password cannot be the same as your %s password.", "System A"), },
+        },
+        {
+          ruleReportAll,
+          TestUtils.newPasswordData("t3stUs3r05", "testuser", null, sources),
+          new String[] {
+            String.format("Password cannot be the same as your %s password.", "System A"),
+            String.format("Password cannot be the same as your %s password.", "System A"),
+          },
         },
       };
   }


### PR DESCRIPTION
We have a convention of using reportAllFailures controlling whether a rule only reports the first failure or all failures.
This PR adds that property to both the HistoryRule and SourceRule.
Note that this changes the default behavior, but this is probably the desired behavior.
See PR #68.