### PR TITLE
Modify API to support BCrypt password history.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.cryptacular</groupId>
       <artifactId>cryptacular</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.3-SNAPSHOT</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/passay/DigestHistoryRule.java
+++ b/src/main/java/org/passay/DigestHistoryRule.java
@@ -4,6 +4,7 @@ package org.passay;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cryptacular.bean.EncodingHashBean;
+import org.cryptacular.bean.HashBean;
 
 /**
  * Rule for determining if a password matches one of any previous digested password a user has chosen. If no password
@@ -16,17 +17,31 @@ public class DigestHistoryRule extends HistoryRule
 {
 
   /** Hash bean to use for comparing hashed passwords. */
-  private final EncodingHashBean hashBean;
+  private final HashBean<String> hashBean;
 
   /** Character set to use for undigested passwords. */
   private Charset charset = StandardCharsets.UTF_8;
 
 
   /**
-   * Creates new digest history rule which operates on password references with the supplied label.
+   * Creates new digest history rule which operates on password references that were digested with the supplied hash.
    *
    * @param  bean  encoding hash bean
    */
+  public DigestHistoryRule(final HashBean<String> bean)
+  {
+    hashBean = bean;
+  }
+
+
+  /**
+   * Creates new digest history rule which operates on password references that were digested with the supplied hash.
+   *
+   * @param  bean  encoding hash bean
+   *
+   * @deprecated  use {@link #DigestHistoryRule(HashBean)}
+   */
+  @Deprecated
   public DigestHistoryRule(final EncodingHashBean bean)
   {
     hashBean = bean;

--- a/src/test/java/org/passay/DigestHistoryRuleTest.java
+++ b/src/test/java/org/passay/DigestHistoryRuleTest.java
@@ -3,6 +3,7 @@ package org.passay;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.cryptacular.bean.BCryptHashBean;
 import org.cryptacular.bean.EncodingHashBean;
 import org.cryptacular.spec.CodecSpec;
 import org.cryptacular.spec.DigestSpec;
@@ -24,6 +25,9 @@ public class DigestHistoryRuleTest extends AbstractRuleTest
   private final List<PasswordData.Reference> saltedDigestRefs = new ArrayList<>();
 
   /** For testing. */
+  private final List<PasswordData.Reference> bcryptDigestRefs = new ArrayList<>();
+
+  /** For testing. */
   private final DigestHistoryRule digestRule = new DigestHistoryRule(
     new EncodingHashBean(new CodecSpec("Base64"), new DigestSpec("SHA1"), 1, false));
 
@@ -34,6 +38,9 @@ public class DigestHistoryRuleTest extends AbstractRuleTest
   /** For testing. */
   private final DigestHistoryRule emptyDigestRule = new DigestHistoryRule(
     new EncodingHashBean(new CodecSpec("Base64"), new DigestSpec("SHA1"), 1, false));
+
+  /** For testing. */
+  private final DigestHistoryRule bcryptDigestRule = new DigestHistoryRule(new BCryptHashBean(5));
 
 
   /** Initialize rules for this test. */
@@ -47,6 +54,11 @@ public class DigestHistoryRuleTest extends AbstractRuleTest
     saltedDigestRefs.add(new PasswordData.HistoricalReference("salted-history", "2DSZvOzGiMnm/Mbxt1M3zNAh7P1GebLG"));
     saltedDigestRefs.add(new PasswordData.HistoricalReference("salted-history", "rv1mF2DuarrF//LPP9+AFJal8bMc9G5z"));
     saltedDigestRefs.add(new PasswordData.HistoricalReference("salted-history", "3lABdWxtWhfGKtXBx4MfiWZ1737KnFuG"));
+
+    bcryptDigestRefs.add(
+      new PasswordData.HistoricalReference(
+        "bcrypt-history",
+        "$2a$5$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe"));
   }
 
 
@@ -100,6 +112,13 @@ public class DigestHistoryRuleTest extends AbstractRuleTest
         {emptyDigestRule, TestUtils.newPasswordData("t3stUs3r01", "testuser"), null, },
         {emptyDigestRule, TestUtils.newPasswordData("t3stUs3r02", "testuser"), null, },
         {emptyDigestRule, TestUtils.newPasswordData("t3stUs3r03", "testuser"), null, },
+
+        {bcryptDigestRule, TestUtils.newPasswordData("p@$$w0rd", "testuser"), null, },
+        {
+          bcryptDigestRule,
+          TestUtils.newPasswordData("password", "testuser", null, bcryptDigestRefs),
+          codes(HistoryRule.ERROR_CODE),
+        },
       };
   }
 


### PR DESCRIPTION
Deprecating the old constructor allows us to stay API compatible.
See #76.