### PR TITLE
Add DigestDictionaryRule.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>org.passay</groupId>
   <artifactId>passay</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.2-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <name>Passay Library</name>
   <description>Library for checking that a password complies with a custom set of rules</description>
   <url>http://www.passay.org</url>
@@ -71,7 +71,7 @@
     <checkstyle.dir>${basedir}/src/main/checkstyle</checkstyle.dir>
     <testng.dir>${basedir}/src/test/testng</testng.dir>
     <assembly.dir>${basedir}/src/main/assembly</assembly.dir>
-    <japicmp.enabled>true</japicmp.enabled>
+    <japicmp.enabled>false</japicmp.enabled>
     <japicmp.oldVersion>1.3.0</japicmp.oldVersion>
   </properties>
 

--- a/src/main/java/org/passay/AbstractDictionaryRule.java
+++ b/src/main/java/org/passay/AbstractDictionaryRule.java
@@ -13,12 +13,6 @@ import org.passay.dictionary.Dictionary;
 public abstract class AbstractDictionaryRule implements Rule
 {
 
-  /** Error code for matching dictionary word. */
-  public static final String ERROR_CODE = "ILLEGAL_WORD";
-
-  /** Error code for matching reversed dictionary word. */
-  public static final String ERROR_CODE_REVERSED = "ILLEGAL_WORD_REVERSED";
-
   /** Dictionary of words. */
   private Dictionary dictionary;
 
@@ -82,7 +76,8 @@ public abstract class AbstractDictionaryRule implements Rule
     String matchingWord = doWordSearch(text);
     if (matchingWord != null) {
       result.setValid(false);
-      result.getDetails().add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(matchingWord)));
+      result.getDetails().add(
+        new RuleResultDetail(getErrorCode(false), createRuleResultDetailParameters(matchingWord)));
     }
     if (matchBackwards && text.length() > 1) {
       text = new StringBuilder(passwordData.getPassword()).reverse().toString();
@@ -90,7 +85,7 @@ public abstract class AbstractDictionaryRule implements Rule
       if (matchingWord != null) {
         result.setValid(false);
         result.getDetails().add(
-          new RuleResultDetail(ERROR_CODE_REVERSED, createRuleResultDetailParameters(matchingWord)));
+          new RuleResultDetail(getErrorCode(true), createRuleResultDetailParameters(matchingWord)));
       }
     }
     return result;
@@ -110,6 +105,16 @@ public abstract class AbstractDictionaryRule implements Rule
     m.put("matchingWord", word);
     return m;
   }
+
+
+  /**
+   * Returns the error code for this rule.
+   *
+   * @param  backwards  whether to return the error code for a backwards match
+   *
+   * @return  properties error code
+   */
+  protected abstract String getErrorCode(boolean backwards);
 
 
   /**

--- a/src/main/java/org/passay/DictionaryRule.java
+++ b/src/main/java/org/passay/DictionaryRule.java
@@ -12,6 +12,13 @@ import org.passay.dictionary.Dictionary;
 public class DictionaryRule extends AbstractDictionaryRule
 {
 
+  /** Error code for matching dictionary word. */
+  public static final String ERROR_CODE = "ILLEGAL_WORD";
+
+  /** Error code for matching reversed dictionary word. */
+  public static final String ERROR_CODE_REVERSED = "ILLEGAL_WORD_REVERSED";
+
+
   /**
    * Creates a new dictionary rule without supplying a dictionary. The dictionary should be set using {@link
    * #setDictionary(Dictionary)}.
@@ -37,5 +44,12 @@ public class DictionaryRule extends AbstractDictionaryRule
       return text;
     }
     return null;
+  }
+
+
+  @Override
+  protected String getErrorCode(final boolean backwards)
+  {
+    return backwards ? ERROR_CODE_REVERSED : ERROR_CODE;
   }
 }

--- a/src/main/java/org/passay/DictionarySubstringRule.java
+++ b/src/main/java/org/passay/DictionarySubstringRule.java
@@ -11,6 +11,13 @@ import org.passay.dictionary.Dictionary;
 public class DictionarySubstringRule extends AbstractDictionaryRule
 {
 
+  /** Error code for matching dictionary word. */
+  public static final String ERROR_CODE = "ILLEGAL_WORD";
+
+  /** Error code for matching reversed dictionary word. */
+  public static final String ERROR_CODE_REVERSED = "ILLEGAL_WORD_REVERSED";
+
+
   /**
    * Creates a new dictionary substring rule. The dictionary should be set using the {@link #setDictionary(Dictionary)}
    * method.
@@ -41,5 +48,12 @@ public class DictionarySubstringRule extends AbstractDictionaryRule
       }
     }
     return null;
+  }
+
+
+  @Override
+  protected String getErrorCode(final boolean backwards)
+  {
+    return backwards ? ERROR_CODE_REVERSED : ERROR_CODE;
   }
 }

--- a/src/main/java/org/passay/DigestDictionaryRule.java
+++ b/src/main/java/org/passay/DigestDictionaryRule.java
@@ -1,0 +1,69 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.cryptacular.bean.HashBean;
+
+/**
+ * Rule for determining if a password matches a digested password that is stored in a dictionary.
+ *
+ * @author  Middleware Services
+ */
+public class DigestDictionaryRule extends AbstractDictionaryRule
+{
+
+  /** Error code for matching dictionary word. */
+  public static final String ERROR_CODE = "ILLEGAL_DIGEST_WORD";
+
+  /** Error code for matching reversed dictionary word. */
+  public static final String ERROR_CODE_REVERSED = "ILLEGAL_DIGEST_WORD_REVERSED";
+
+  /** Hash bean to use for comparing hashed passwords. */
+  private final HashBean<String> hashBean;
+
+  /** Character set to use for undigested passwords. */
+  private Charset charset = StandardCharsets.UTF_8;
+
+
+  /**
+   * Creates new digest history rule which operates on password references that were digested with the supplied hash.
+   *
+   * @param  bean  encoding hash bean
+   */
+  public DigestDictionaryRule(final HashBean<String> bean)
+  {
+    hashBean = bean;
+  }
+
+
+  /**
+   * Sets the character set to use for undigested passwords.
+   *
+   * @param  set  to use for undigested passwords
+   */
+  public void setCharset(final Charset set)
+  {
+    if (set == null) {
+      throw new NullPointerException("Character set cannot be null");
+    }
+    charset = set;
+  }
+
+
+  @Override
+  protected String doWordSearch(final String text)
+  {
+    if (getDictionary().search(hashBean.hash(text.getBytes(charset)))) {
+      return text;
+    }
+    return null;
+  }
+
+
+  @Override
+  protected String getErrorCode(final boolean backwards)
+  {
+    return backwards ? ERROR_CODE_REVERSED : ERROR_CODE;
+  }
+}

--- a/src/main/java/org/passay/DigestHistoryRule.java
+++ b/src/main/java/org/passay/DigestHistoryRule.java
@@ -3,7 +3,6 @@ package org.passay;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.cryptacular.bean.EncodingHashBean;
 import org.cryptacular.bean.HashBean;
 
 /**
@@ -29,20 +28,6 @@ public class DigestHistoryRule extends HistoryRule
    * @param  bean  encoding hash bean
    */
   public DigestHistoryRule(final HashBean<String> bean)
-  {
-    hashBean = bean;
-  }
-
-
-  /**
-   * Creates new digest history rule which operates on password references that were digested with the supplied hash.
-   *
-   * @param  bean  encoding hash bean
-   *
-   * @deprecated  use {@link #DigestHistoryRule(HashBean)}
-   */
-  @Deprecated
-  public DigestHistoryRule(final EncodingHashBean bean)
   {
     hashBean = bean;
   }

--- a/src/main/java/org/passay/DigestSourceRule.java
+++ b/src/main/java/org/passay/DigestSourceRule.java
@@ -3,7 +3,7 @@ package org.passay;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import org.cryptacular.bean.EncodingHashBean;
+import org.cryptacular.bean.HashBean;
 
 /**
  * Rule for determining if a password matches a digested password from a different source. Useful for when separate
@@ -16,7 +16,7 @@ public class DigestSourceRule extends SourceRule
 {
 
   /** Hash bean to use for comparing hashed passwords. */
-  private final EncodingHashBean hashBean;
+  private final HashBean<String> hashBean;
 
   /** Character set to use for undigested passwords. */
   private Charset charset = StandardCharsets.UTF_8;
@@ -27,7 +27,7 @@ public class DigestSourceRule extends SourceRule
    *
    * @param  bean  encoding hash bean
    */
-  public DigestSourceRule(final EncodingHashBean bean)
+  public DigestSourceRule(final HashBean<String> bean)
   {
     hashBean = bean;
   }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,6 +1,8 @@
 HISTORY_VIOLATION=Password matches one of %1$s previous passwords.
 ILLEGAL_WORD=Password contains the dictionary word '%1$s'.
 ILLEGAL_WORD_REVERSED=Password contains the reversed dictionary word '%1$s'.
+ILLEGAL_DIGEST_WORD=Password contains a dictionary word.
+ILLEGAL_DIGEST_WORD_REVERSED=Password contains a reversed dictionary word.
 ILLEGAL_MATCH=Password matches the illegal pattern '%1$s'.
 ALLOWED_MATCH=Password must match pattern '%1$s'.
 ILLEGAL_CHAR=Password %2$s the illegal character '%1$s'.

--- a/src/test/java/org/passay/DigestDictionaryRuleTest.java
+++ b/src/test/java/org/passay/DigestDictionaryRuleTest.java
@@ -1,0 +1,122 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+import org.cryptacular.bean.EncodingHashBean;
+import org.cryptacular.spec.CodecSpec;
+import org.cryptacular.spec.DigestSpec;
+import org.passay.dictionary.Dictionary;
+import org.passay.dictionary.DictionaryBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Parameters;
+
+/**
+ * Unit test for {@link DigestDictionaryRule}.
+ *
+ * @author  Middleware Services
+ */
+public class DigestDictionaryRuleTest extends AbstractRuleTest
+{
+
+  /** For testing. */
+  private final DigestDictionaryRule rule = new DigestDictionaryRule(
+    new EncodingHashBean(new CodecSpec("Hex-Upper"), new DigestSpec("SHA1")));
+
+  /** For testing. */
+  private final DigestDictionaryRule backwardsRule = new DigestDictionaryRule(
+    new EncodingHashBean(new CodecSpec("Hex-Upper"), new DigestSpec("SHA1")));
+
+
+  /**
+   * Initialize rules for this test.
+   *
+   * @param  dictFile  dictionary file to read
+   *
+   * @throws  Exception  if dictionary files cannot be read
+   */
+  @Parameters("digestDictionaryFile")
+  @BeforeClass(groups = {"passtest"})
+  public void createRules(final String dictFile)
+    throws Exception
+  {
+    final Dictionary caseSensitiveDict = new DictionaryBuilder().addFile(dictFile).setCaseSensitive(true).build();
+
+    rule.setDictionary(caseSensitiveDict);
+
+    backwardsRule.setDictionary(caseSensitiveDict);
+    backwardsRule.setMatchBackwards(true);
+  }
+
+
+  /**
+   * @return  Test data.
+   *
+   * @throws  Exception  On test data generation failure.
+   */
+  @DataProvider(name = "passwords")
+  public Object[][] passwords()
+    throws Exception
+  {
+    return
+      new Object[][] {
+        // valid password
+        {rule, new PasswordData("JM@Ntr3xS801!!"), null, },
+        // dictionary word
+        {
+          rule,
+          new PasswordData("JMANtrex5801!!"),
+          codes(DigestDictionaryRule.ERROR_CODE),
+        },
+        // backwards dictionary word
+        {rule, new PasswordData("!!1085xertNAMJ"), null, },
+        // mixed case dictionary word
+        {rule, new PasswordData("jmanTREX5801!!"), null, },
+        // backwards mixed case dictionary word
+        {rule, new PasswordData("!!1085XERTnamj"), null, },
+
+        // valid password
+        {backwardsRule, new PasswordData("JM@Ntr3xS801!!"), null, },
+        // dictionary word
+        {
+          backwardsRule,
+          new PasswordData("JMANtrex5801!!"),
+          codes(DigestDictionaryRule.ERROR_CODE),
+        },
+        // backward dictionary word
+        {
+          backwardsRule,
+          new PasswordData("!!1085xertNAMJ"),
+          codes(DigestDictionaryRule.ERROR_CODE_REVERSED),
+        },
+        // mixed case dictionary word
+        {backwardsRule, new PasswordData("jmanTREX5801!!"), null, },
+        // backwards mixed case dictionary word
+        {backwardsRule, new PasswordData("!!1085XERTnamj"), null, },
+      };
+  }
+
+
+  /**
+   * @return  Test data.
+   *
+   * @throws  Exception  On test data generation failure.
+   */
+  @DataProvider(name = "messages")
+  public Object[][] messages()
+    throws Exception
+  {
+    return
+      new Object[][] {
+        {
+          rule,
+          new PasswordData("JMANtrex5801!!"),
+          new String[] {"Password contains a dictionary word.", },
+        },
+        {
+          backwardsRule,
+          new PasswordData("!!1085xertNAMJ"),
+          new String[] {"Password contains a reversed dictionary word.", },
+        },
+      };
+  }
+}

--- a/src/test/testng/testng.xml
+++ b/src/test/testng/testng.xml
@@ -5,6 +5,7 @@
 
   <!-- passay test parameters -->
   <parameter name="dictionaryFile" value="src/test/resources/web2-gt3"/>
+  <parameter name="digestDictionaryFile" value="src/test/resources/sha1s.txt"/>
 
   <!-- dictionary test parameters -->
   <parameter name="webFile" value="src/test/resources/web2"/>


### PR DESCRIPTION
Required a minor version bump as the changes to AbstractDictionaryRule broke API compatibility.
Removed deprecated methods from DigestHistoryRule and DigestSourceRule.
Fixes #78.