### PR TITLE
fix for issue 82

### DIFF
--- a/src/main/java/org/passay/HistoryRule.java
+++ b/src/main/java/org/passay/HistoryRule.java
@@ -20,6 +20,12 @@ public class HistoryRule implements Rule
   /** Whether to report all history matches or just the first. */
   protected boolean reportAllFailures;
 
+  /** The size of the password history to be displayed in the error message
+   *  instead of the size of provided password reference list
+   *  (e.g. message is "password can't match the previous 4 passwords" but
+   *  the historical password reference list size is only 1) */
+  protected Integer sizeToReport;
+
 
   /**
    * Creates a new history rule.
@@ -92,7 +98,17 @@ public class HistoryRule implements Rule
   protected Map<String, Object> createRuleResultDetailParameters(final int size)
   {
     final Map<String, Object> m = new LinkedHashMap<>();
-    m.put("historySize", size);
+    m.put("historySize", sizeToReport == null ? size : sizeToReport);
     return m;
+  }
+
+
+  /**
+   * Sets the size to report if the password is not valid
+   *
+   * @param sizeToReport The size to report
+   */
+  public void setSizeToReport(int sizeToReport) {
+    this.sizeToReport = sizeToReport;
   }
 }

--- a/src/main/java/org/passay/HistoryRule.java
+++ b/src/main/java/org/passay/HistoryRule.java
@@ -106,9 +106,10 @@ public class HistoryRule implements Rule
   /**
    * Sets the size to report if the password is not valid
    *
-   * @param sizeToReport The size to report
+   * @param size The size to report
    */
-  public void setSizeToReport(int sizeToReport) {
-    this.sizeToReport = sizeToReport;
+  public void setSizeToReport(final int size)
+  {
+    sizeToReport = size;
   }
 }

--- a/src/test/java/org/passay/HistoryRuleTest.java
+++ b/src/test/java/org/passay/HistoryRuleTest.java
@@ -24,6 +24,9 @@ public class HistoryRuleTest extends AbstractRuleTest
   private final HistoryRule ruleReportFirst = new HistoryRule(false);
 
   /** For testing. */
+  private final HistoryRule ruleSizeToReport = new HistoryRule();
+
+    /** For testing. */
   private final HistoryRule emptyRule = new HistoryRule();
 
 
@@ -35,6 +38,7 @@ public class HistoryRuleTest extends AbstractRuleTest
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r02"));
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r03"));
     history.add(new PasswordData.HistoricalReference("history", "t3stUs3r02"));
+    ruleSizeToReport.setSizeToReport(100);
   }
 
 
@@ -84,6 +88,12 @@ public class HistoryRuleTest extends AbstractRuleTest
           codes(HistoryRule.ERROR_CODE),
         },
 
+        {
+          ruleSizeToReport,
+          TestUtils.newPasswordData("t3stUs3r03", "testuser", null, history),
+          codes(HistoryRule.ERROR_CODE),
+        },
+
         {emptyRule, TestUtils.newPasswordData("t3stUs3r00", "testuser"), null, },
         {emptyRule, TestUtils.newPasswordData("t3stUs3r01", "testuser"), null, },
         {emptyRule, TestUtils.newPasswordData("t3stUs3r02", "testuser"), null, },
@@ -120,6 +130,11 @@ public class HistoryRuleTest extends AbstractRuleTest
           ruleReportFirst,
           TestUtils.newPasswordData("t3stUs3r02", "testuser", null, history),
           new String[] {String.format("Password matches one of %s previous passwords.", history.size()), },
+        },
+        {
+          ruleSizeToReport,
+          TestUtils.newPasswordData("t3stUs3r01", "testuser", null, history),
+          new String[] {String.format("Password matches one of 100 previous passwords."), },
         },
       };
   }


### PR DESCRIPTION
Added new property sizeToReport. The size of the password history to be displayed in the error message instead of the size of provided password reference list (e.g. message is "password can't match the previous 4 passwords" but the historical password reference list size is only 1)

Signed-off-by: Juan A. Velez <jvelez@chibchasoft.com>