### PR TITLE
Ternary Tree print improvements

### DIFF
--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.StringTokenizer;
 
 /**
  * Implementation of a ternary tree. Methods are provided for inserting strings and searching for strings. The
@@ -209,7 +208,9 @@ public class TernaryTree
   public void print(final Writer out)
     throws IOException
   {
-    out.write(printNode(root, "", 0));
+    final StringBuilder buffer = new StringBuilder();
+    printNode(root, "", 0, buffer);
+    out.write(buffer.toString());
     out.flush();
   }
 
@@ -456,39 +457,31 @@ public class TernaryTree
 
 
   /**
-   * Recursively traverses every node in the ternary tree one node at a time beginning at the supplied node. The result
-   * is an ASCII string representation of the tree beginning at the supplied node.
+   * Recursively traverses every node in the ternary tree rooted at the supplied node.
+   * The result is an ASCII string representation of the tree rooted at the supplied node.
    *
    * @param  node  to begin traversing
-   * @param  s  string of words found at the supplied node
-   * @param  depth  of the current node
-   *
-   * @return  string containing all words from the supplied node
+   * @param  s  the string representation of the current chain of equal kid nodes
+   * @param  depth  depth of the current chain of nodes
+   * @param  buffer  the buffer to which the output is printed
    */
-  private String printNode(final TernaryNode node, final String s, final int depth)
+  private void printNode(final TernaryNode node, final String s, final int depth, final StringBuilder buffer)
   {
-    final StringBuilder buffer = new StringBuilder();
     if (node != null) {
-      buffer.append(printNode(node.getLokid(), " <-", depth + 1));
+      printNode(node.getLokid(), " <-", depth + 1, buffer);
 
-      final String c = String.valueOf(node.getSplitChar());
-      final StringBuilder eq = new StringBuilder();
+      final char c = node.getSplitChar();
       if (node.getEqkid() != null) {
-        eq.append(printNode(node.getEqkid(), s + c + "--", depth + 1));
+        printNode(node.getEqkid(), s + c + "--", depth + 1, buffer);
       } else {
-        int count = (new StringTokenizer(s, "--")).countTokens();
-        if (count > 0) {
-          count--;
+        final int count = s.split("[-<>]-").length;
+        for (int i = 1; i < depth - count; i++) {
+          buffer.append("   ");
         }
-        for (int i = 1; i < depth - count - 1; i++) {
-          eq.append("   ");
-        }
-        eq.append(s).append(c).append(TernaryTree.LINE_SEPARATOR);
+        buffer.append(s).append(c).append(TernaryTree.LINE_SEPARATOR);
       }
-      buffer.append(eq);
 
-      buffer.append(printNode(node.getHikid(), " >-", depth + 1));
+      printNode(node.getHikid(), " >-", depth + 1, buffer);
     }
-    return buffer.toString();
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -468,20 +468,18 @@ public class TernaryTree
   private void printNode(final TernaryNode node, final String s, final int depth, final StringBuilder buffer)
   {
     if (node != null) {
-      printNode(node.getLokid(), " <-", depth + 1, buffer);
+      printNode(node.getLokid(), s + " <-", depth + 1, buffer);
 
       final char c = node.getSplitChar();
       if (node.getEqkid() != null) {
         printNode(node.getEqkid(), s + c + "--", depth + 1, buffer);
       } else {
-        final int count = s.split("[-<>]-").length;
-        for (int i = 1; i < depth - count; i++) {
-          buffer.append("   ");
-        }
-        buffer.append(s).append(c).append(TernaryTree.LINE_SEPARATOR);
+        final int i = Math.max(s.lastIndexOf(" <-"), s.lastIndexOf(" >-"));
+        final String line = i < 0 ? s : s.substring(0, i).replaceAll(".", " ") + s.substring(i);
+        buffer.append(line).append(c).append(TernaryTree.LINE_SEPARATOR);
       }
 
-      printNode(node.getHikid(), " >-", depth + 1, buffer);
+      printNode(node.getHikid(), s + " >-", depth + 1, buffer);
     }
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -488,19 +488,19 @@ public class TernaryTree
     final boolean fullPath, final StringBuilder buffer)
   {
     if (node != null) {
-      printNode(node.getLokid(), s + " <-", depth + 1, fullPath, buffer);
+      printNode(node.getLokid(), s + "  /", depth + 1, fullPath, buffer);
 
       final char c = node.getSplitChar();
       if (node.getEqkid() != null) {
-        final String suffix = node.isEndOfWord() ? "=-" : "--";
-        printNode(node.getEqkid(), s + c + suffix, depth + 1, fullPath, buffer);
+        final String suffix = node.isEndOfWord() ? "=" : "-";
+        printNode(node.getEqkid(), s + '-' + c + suffix, depth + 1, fullPath, buffer);
       } else {
-        final int i = fullPath ? -1 : Math.max(s.lastIndexOf(" <-"), s.lastIndexOf(" >-"));
+        final int i = fullPath ? -1 : Math.max(s.lastIndexOf("  /"), s.lastIndexOf("  \\"));
         final String line = i < 0 ? s : s.substring(0, i).replaceAll(".", " ") + s.substring(i);
-        buffer.append(line).append(c).append(TernaryTree.LINE_SEPARATOR);
+        buffer.append(line).append('-').append(c).append(TernaryTree.LINE_SEPARATOR);
       }
 
-      printNode(node.getHikid(), s + " >-", depth + 1, fullPath, buffer);
+      printNode(node.getHikid(), s + "  \\", depth + 1, fullPath, buffer);
     }
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -202,16 +202,33 @@ public class TernaryTree
    * whether or not your tree is balanced.
    *
    * @param  out  to print to
+   * @param  fullPath  specifies whether each line should show the full path from root or only the suffix
+   *
+   * @throws  IOException  if an error occurs
+   */
+  public void print(final Writer out, final boolean fullPath)
+    throws IOException
+  {
+    final StringBuilder buffer = new StringBuilder();
+    printNode(root, "", 0, fullPath, buffer);
+    out.write(buffer.toString());
+    out.flush();
+  }
+
+
+  /**
+   * Prints an ASCII representation of this ternary tree to the supplied writer. This is a very expensive operation,
+   * every node in the tree is traversed. The output produced is hard to read, but it should give an indication of
+   * whether or not your tree is balanced.
+   *
+   * @param  out  to print to
    *
    * @throws  IOException  if an error occurs
    */
   public void print(final Writer out)
-    throws IOException
+          throws IOException
   {
-    final StringBuilder buffer = new StringBuilder();
-    printNode(root, "", 0, buffer);
-    out.write(buffer.toString());
-    out.flush();
+    print(out, false);
   }
 
 
@@ -463,24 +480,27 @@ public class TernaryTree
    * @param  node  to begin traversing
    * @param  s  the string representation of the current chain of equal kid nodes
    * @param  depth  depth of the current chain of nodes
+   * @param  fullPath  specifies whether each line should show the full path from root or only the suffix
    * @param  buffer  the buffer to which the output is printed
    */
-  private void printNode(final TernaryNode node, final String s, final int depth, final StringBuilder buffer)
+  private void printNode(
+    final TernaryNode node, final String s, final int depth,
+    final boolean fullPath, final StringBuilder buffer)
   {
     if (node != null) {
-      printNode(node.getLokid(), s + " <-", depth + 1, buffer);
+      printNode(node.getLokid(), s + " <-", depth + 1, fullPath, buffer);
 
       final char c = node.getSplitChar();
       if (node.getEqkid() != null) {
         final String suffix = node.isEndOfWord() ? "=-" : "--";
-        printNode(node.getEqkid(), s + c + suffix, depth + 1, buffer);
+        printNode(node.getEqkid(), s + c + suffix, depth + 1, fullPath, buffer);
       } else {
-        final int i = Math.max(s.lastIndexOf(" <-"), s.lastIndexOf(" >-"));
+        final int i = fullPath ? -1 : Math.max(s.lastIndexOf(" <-"), s.lastIndexOf(" >-"));
         final String line = i < 0 ? s : s.substring(0, i).replaceAll(".", " ") + s.substring(i);
         buffer.append(line).append(c).append(TernaryTree.LINE_SEPARATOR);
       }
 
-      printNode(node.getHikid(), s + " >-", depth + 1, buffer);
+      printNode(node.getHikid(), s + " >-", depth + 1, fullPath, buffer);
     }
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -472,7 +472,8 @@ public class TernaryTree
 
       final char c = node.getSplitChar();
       if (node.getEqkid() != null) {
-        printNode(node.getEqkid(), s + c + "--", depth + 1, buffer);
+        final String suffix = node.isEndOfWord() ? "=-" : "--";
+        printNode(node.getEqkid(), s + c + suffix, depth + 1, buffer);
       } else {
         final int i = Math.max(s.lastIndexOf(" <-"), s.lastIndexOf(" >-"));
         final String line = i < 0 ? s : s.substring(0, i).replaceAll(".", " ") + s.substring(i);

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -210,6 +210,7 @@ public class TernaryTree
     throws IOException
   {
     out.write(printNode(root, "", 0));
+    out.flush();
   }
 
 

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -165,6 +165,7 @@ public class TernaryTreeDictionary implements Dictionary
       boolean partialSearch = false;
       boolean nearSearch = false;
       boolean print = false;
+      boolean printPath = false;
 
       // operation parameters
       String word = null;
@@ -187,6 +188,8 @@ public class TernaryTreeDictionary implements Dictionary
           distance = Integer.parseInt(args[++i]);
         } else if ("-p".equals(args[i])) {
           print = true;
+        } else if ("-pp".equals(args[i])) {
+          printPath = true;
         } else if ("-h".equals(args[i])) {
           throw new ArrayIndexOutOfBoundsException();
         } else {
@@ -226,8 +229,8 @@ public class TernaryTreeDictionary implements Dictionary
             word,
             distance,
             Arrays.asList(matches)));
-      } else if (print) {
-        dict.getTernaryTree().print(new PrintWriter(System.out, true));
+      } else if (print || printPath) {
+        dict.getTernaryTree().print(new PrintWriter(System.out, true), printPath);
       } else {
         throw new ArrayIndexOutOfBoundsException();
       }

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -249,7 +249,8 @@ public class TernaryTreeDictionary implements Dictionary
       System.out.println("           (where word like '.a.a.a') \\");
       System.out.println("       -ns <word> <distance> " +
         "(Near search for a word) \\");
-      System.out.println("       -p (Print the entire dictionary " + "in tree form) \\");
+      System.out.println("       -p (Print the entire dictionary " + "in tree form, path suffixes only) \\");
+      System.out.println("       -pp (Print the entire dictionary " + "in tree form, full paths) \\");
       System.out.println("       -h (Print this message) \\");
       System.exit(1);
     }


### PR DESCRIPTION
Ternary Tree had some bugs in its printing implementation, like not printing the complete tree (or not printing at all small trees) on some platforms, first-level indentation was wrong (some second-level nodes appeared at the same indentation of the root node), etc.

Also optimized it to use a single StringBuilder instead of creating a whole lot of them, made the code shorter and cleaner, added command line option to print the full path on every line (easier for some analyses, and useful to see full words and not just their suffix), added indication of words ending in the middle of a path (prefix of other words), and changed the chars and spacing to make the printout look more like a standard tree diagram.

This helped me in analysing and understanding later modifications and their effect on the tree structure, correctness and performance.