### PR TITLE
Ternary Tree node depth statistics

### DIFF
--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -6,7 +6,9 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of a ternary tree. Methods are provided for inserting strings and searching for strings. The
@@ -472,5 +474,38 @@ public class TernaryTree
 
       printNode(node.getHikid(), s + "  \\", depth + 1, fullPath, buffer);
     }
+  }
+
+  /**
+   * Returns a histogram of how many words end at each depth.
+   *
+   * @param node the node at the root of the tree to count
+   * @param depth the depth of the node from root
+   * @param histogram the depth count histogram to update
+   * @return a histogram of how many words end at each depth
+   */
+  private Map<Integer, Integer> getNodeStats(
+    final TernaryNode node, final int depth,
+    final Map<Integer, Integer> histogram)
+  {
+    if (node != null) {
+      if (node.isEndOfWord()) {
+        histogram.put(depth, histogram.getOrDefault(depth, 0) + 1);
+      }
+      getNodeStats(node.getLokid(), depth + 1, histogram);
+      getNodeStats(node.getEqkid(), depth + 1, histogram);
+      getNodeStats(node.getHikid(), depth + 1, histogram);
+    }
+    return histogram;
+  }
+
+  /**
+   * Returns a histogram of how many words end at each depth.
+   *
+   * @return a histogram of how many words end at each depth
+   */
+  protected Map<Integer, Integer> getNodeStats()
+  {
+    return getNodeStats(root, 0, new HashMap<>());
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -161,6 +161,7 @@ public class TernaryTreeDictionary implements Dictionary
       boolean nearSearch = false;
       boolean print = false;
       boolean printPath = false;
+      boolean stats = false;
 
       // operation parameters
       String word = null;
@@ -185,6 +186,8 @@ public class TernaryTreeDictionary implements Dictionary
           print = true;
         } else if ("-pp".equals(args[i])) {
           printPath = true;
+        } else if ("-st".equals(args[i])) {
+          stats = true;
         } else if ("-h".equals(args[i])) {
           throw new ArrayIndexOutOfBoundsException();
         } else {
@@ -226,6 +229,9 @@ public class TernaryTreeDictionary implements Dictionary
             Arrays.asList(matches)));
       } else if (print || printPath) {
         dict.getTernaryTree().print(new PrintWriter(System.out, true), printPath);
+      } else if (stats) {
+        System.out.println("word path depths histogram:");
+        System.out.println(dict.getTernaryTree().getNodeStats());
       } else {
         throw new ArrayIndexOutOfBoundsException();
       }
@@ -246,6 +252,7 @@ public class TernaryTreeDictionary implements Dictionary
         "(Near search for a word) \\");
       System.out.println("       -p (Print the entire dictionary " + "in tree form, path suffixes only) \\");
       System.out.println("       -pp (Print the entire dictionary " + "in tree form, full paths) \\");
+      System.out.println("       -st (Print the tree node depth statistics) \\");
       System.out.println("       -h (Print this message) \\");
       System.exit(1);
     }

--- a/src/test/java/org/passay/dictionary/TernaryTreeDictionaryPerfTest.java
+++ b/src/test/java/org/passay/dictionary/TernaryTreeDictionaryPerfTest.java
@@ -2,6 +2,7 @@
 package org.passay.dictionary;
 
 import java.io.RandomAccessFile;
+import java.util.Map;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
@@ -39,6 +40,8 @@ public class TernaryTreeDictionaryPerfTest extends AbstractDictionaryPerfTest
     ttd = new TernaryTreeDictionary(new FileWordList(new RandomAccessFile(webFile, "r")));
     t = System.currentTimeMillis() - t;
     System.out.println(ttd.getClass().getSimpleName() + " time to construct: " + t + "ms");
+    final Map<Integer, Integer> depths = ttd.getTernaryTree().getNodeStats();
+    System.out.println(ttd.getClass().getSimpleName() + " depth histogram: " + depths);
   }
 
 


### PR DESCRIPTION
In order to analyze the tree structure, implementation changes and optimizations, it is very useful to see statistics on the tree, specifically the histogram of how many nodes are at each depth (path length) in the tree. Other than just looking at the numbers, this makes it easy to copy&paste the data into Matlab/Octave to make nice graphs for visualizing performance comparisons etc.

These commits add this functionality to the tree, print them out in the (already existing) performance tests, and add a command line option to print them out on any given input.