### PR TITLE
Re-implement MedianIterator to use a proper sequence of medians

### DIFF
--- a/src/main/java/org/passay/dictionary/AbstractWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractWordList.java
@@ -76,6 +76,11 @@ public abstract class AbstractWordList implements WordList
     /** Index of next word in the iterator sequence. */
     protected int index;
 
+    @Override
+    public boolean hasNext()
+    {
+      return index < size();
+    }
 
     @Override
     public void remove()
@@ -93,18 +98,12 @@ public abstract class AbstractWordList implements WordList
    */
   private class SequentialIterator extends AbstractWordListIterator
   {
-
-
-    @Override
-    public boolean hasNext()
-    {
-      return index < size();
-    }
-
-
     @Override
     public String next()
     {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
       return get(index++);
     }
   }
@@ -157,12 +156,6 @@ public abstract class AbstractWordList implements WordList
         // rounding them down properly)
         return (int) ((size * remainder - 1) / leftovers);
       }
-    }
-
-    @Override
-    public boolean hasNext()
-    {
-      return index < size();
     }
 
     @Override

--- a/src/main/java/org/passay/dictionary/AbstractWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractWordList.java
@@ -3,6 +3,7 @@ package org.passay.dictionary;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Provides common operations implementations for word lists.
@@ -72,7 +73,7 @@ public abstract class AbstractWordList implements WordList
   private abstract class AbstractWordListIterator implements Iterator<String>
   {
 
-    /** Index of next word in list. */
+    /** Index of next word in the iterator sequence. */
     protected int index;
 
 
@@ -110,55 +111,67 @@ public abstract class AbstractWordList implements WordList
 
 
   /**
-   * Iterator that iterates over a word list from the median outward to either end. In particular, for a word list of N
-   * elements whose median index is M, and for each i such that M-i >= 0 and M+i < N, the M-i element is visited before
-   * the M+i element.
+   * Iterator that iterates over a word list by following a sequence of medians.
+   * This enables the creation of a well-balanced search tree from a sorted word list.
+   * <p>
+   * The sequence of median indices starts with the global median,
+   * followed by the median of the left half, the median of the right half,
+   * the median of the left half of the left half, etc. (recursively).
    *
-   * @author  Middleware Services
+   * @author  Amichai Rothman
+   * @author  Ronen Zilberman
    */
   private class MedianIterator extends AbstractWordListIterator
   {
 
-    /** Index of median element in given list. */
-    private final int median = size() / 2;
-
-    /** Indicates direction of next item. */
-    private int sign;
-
+    /**
+     * Returns the i-th element in the sequence of median indices of the given size.
+     *
+     * @param i the index within the median sequence of the element to return
+     * @param size the size of the sequence
+     * @return the i-th element in the median indices sequence
+     */
+    int toMedianIndex(final int i, final int size)
+    {
+      // we use long multiplication to avoid int overflow
+      // (good for all int inputs, beyond that double arithmetic is required)
+      final int powerOfTwo = Integer.highestOneBit(i + 1);
+      final long remainder = (i + 1) - powerOfTwo;
+      final int leftovers = size - powerOfTwo;
+      // all power of two levels that we can fill up completely go to the first case,
+      // the leftovers in the last incomplete power of two level go to the second case
+      // (also the special case of index 0 of the leftovers goes to the first
+      // case just so it'll return 0 and not fail due to an edge-case of rounding)
+      if (leftovers >= powerOfTwo || remainder == 0) {
+        // find the correct fraction (power of two denominator
+        // and indexed odd-numbered numerator), and multiply by size
+        // to get our median index
+        return (int) (size * (2 * remainder + 1) / (2 * powerOfTwo));
+      } else {
+        // find the correct fraction (denominator is the number of leftover
+        // items in the incomplete last power of two level, and indexed
+        // numerator), and multiply by size to get our median index.
+        // note that the leftovers (indices that were not returned by
+        // any of the smaller power of two levels) are evenly spaced,
+        // so they can be trivially calculated, with the added -1 for
+        // rounding them down properly)
+        return (int) ((size * remainder - 1) / leftovers);
+      }
+    }
 
     @Override
     public boolean hasNext()
     {
-      final int n = size();
-      final boolean result;
-      if (sign > 0) {
-        result = median + index < n;
-      } else if (sign < 0) {
-        result = median - index >= 0;
-      } else {
-        result = n > 0;
-      }
-      return result;
+      return index < size();
     }
-
 
     @Override
     public String next()
     {
-      final String next;
-      if (sign > 0) {
-        next = get(median + index);
-        sign = -1;
-        index++;
-      } else if (sign < 0) {
-        next = get(median - index);
-        sign = 1;
-      } else {
-        next = get(median);
-        sign = -1;
-        index = 1;
+      if (!hasNext()) {
+        throw new NoSuchElementException();
       }
-      return next;
+      return get(toMedianIndex(index++, size()));
     }
   }
 }

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -237,7 +237,7 @@ public class TernaryTreeDictionary implements Dictionary
         "<options> <operation> \\");
       System.out.println("");
       System.out.println("where <options> includes:");
-      System.out.println("       -m (Insert dictionary using it's median) \\");
+      System.out.println("       -m (Insert dictionary using its medians) \\");
       System.out.println("       -ci (Make search case-insensitive) \\");
       System.out.println("");
       System.out.println("where <operation> includes:");

--- a/src/main/java/org/passay/dictionary/WordList.java
+++ b/src/main/java/org/passay/dictionary/WordList.java
@@ -41,7 +41,7 @@ public interface WordList
 
 
   /**
-   * Returns an iterator to traverse this word list from the median.
+   * Returns an iterator to traverse this word list by following a recursive sequence of medians.
    *
    * @return  iterator for this word list
    */


### PR DESCRIPTION
The previous implementation of MedianIterator didn't actually iterate over medians, it just started from the global median and then flip-flopped between higher and lower elements in sequential order (not sure how the sign flipping was better than just a simple sequential loop.)

The new implementation actually follows a full sequence of medians in a recursive-like manner. This allows search trees constructed from a sorted wordlist to be well-balanced, providing much better tree search performance. In the existing performance unit test it shows around 40% improvement in search speed.

If you merge the other PRs from today first, you can also print out the tree structure before/after this change and see how much more balanced it looks, or print out the node depth histogram and see the numbers. I've also attached here for your amusement a plot of the histograms for various iterator implementations (depth of all end-of-word nodes vs how many times each depth occurs in the tree) - the orange curve is the previous implementation, the green curve is a random insertion order, the purple curve is an implementation that follows medians of a power of two greater than or equal to to the data size and skips the indices that are beyond the data size, and the yellow curve is the current implementation which is the series of medians for the exact data size (it almost exactly coincides with the purple curve, but ever so slightly better, and is more elegant in implementation and in theory). Note that even the longest paths in the current implementation are shorter than the average path length in the previous implementation!

This was fun :-)

![tree hist3](https://user-images.githubusercontent.com/1410200/52790224-b6a03800-306e-11e9-9c77-285f0f63e9ff.png)
