### PR TITLE
Simplify and optimize IllegalSequenceRule

### DIFF
--- a/src/test/java/org/passay/IllegalSequenceRuleTest.java
+++ b/src/test/java/org/passay/IllegalSequenceRuleTest.java
@@ -36,6 +36,42 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
           new PasswordData("pqwerty#n65"),
           codes(EnglishSequenceData.USQwerty.getErrorCode()),
         },
+        // Has qwerty sequence at beginning
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("qwerty#n65"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode()),
+        },
+        // Has qwerty sequence at end
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("ppqwerty"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode()),
+        },
+        // Has qwerty sequence in entirety
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("qwerty"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode()),
+        },
+        // Has two qwerty sequences
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("pqwerty#n65tyuiop"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode(), EnglishSequenceData.USQwerty.getErrorCode()),
+        },
+        // Has two joined qwerty sequences
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("qwertytrewq"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode(), EnglishSequenceData.USQwerty.getErrorCode()),
+        },
+        // Has two joined qwerty sequences with padding
+        {
+          new IllegalSequenceRule(EnglishSequenceData.USQwerty, 6, false),
+          new PasswordData("pqwertytrewqp"),
+          codes(EnglishSequenceData.USQwerty.getErrorCode(), EnglishSequenceData.USQwerty.getErrorCode()),
+        },
         // Has wrapping qwerty sequence with wrap=false
         {
           new IllegalSequenceRule(EnglishSequenceData.USQwerty),
@@ -52,7 +88,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.USQwerty, 4, false),
           new PasswordData("p7^54#n65"),
-          codes(EnglishSequenceData.USQwerty.getErrorCode(), EnglishSequenceData.USQwerty.getErrorCode()),
+          codes(EnglishSequenceData.USQwerty.getErrorCode()),
         },
         // Has backward wrapping qwerty sequence with wrap=false
         {
@@ -89,7 +125,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.USQwerty, 4, false),
           new PasswordData("p7§5›#n65"),
-          codes(EnglishSequenceData.USQwerty.getErrorCode(), EnglishSequenceData.USQwerty.getErrorCode()),
+          codes(EnglishSequenceData.USQwerty.getErrorCode()),
         },
         // Has backward alt wrapping qwerty sequence with wrap=false
         {
@@ -254,10 +290,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.Numerical, 5, true),
           new PasswordData("1234567"),
-          codes(
-            EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode()),
+          codes(EnglishSequenceData.Numerical.getErrorCode()),
         },
         // report single error
         {
@@ -288,7 +321,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.USQwerty, 5, true, false),
           new PasswordData("pkl;'asd65"),
-          new String[] {String.format("Password contains the illegal QWERTY sequence '%s'.", "kl;'a"), },
+          new String[] {String.format("Password contains the illegal QWERTY sequence '%s'.", "kl;'asd"), },
         },
         {
           new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
@@ -298,7 +331,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.Alphabetical, 5, true, false),
           new PasswordData("phijklmno#n65"),
-          new String[] {String.format("Password contains the illegal alphabetical sequence '%s'.", "hijkl"), },
+          new String[] {String.format("Password contains the illegal alphabetical sequence '%s'.", "hijklmno"), },
         },
         {
           new IllegalSequenceRule(EnglishSequenceData.Numerical),
@@ -308,7 +341,7 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
         {
           new IllegalSequenceRule(EnglishSequenceData.Numerical, 5, false, false),
           new PasswordData("p3456789n65"),
-          new String[] {String.format("Password contains the illegal numerical sequence '%s'.", "34567"), },
+          new String[] {String.format("Password contains the illegal numerical sequence '%s'.", "3456789"), },
         },
       };
   }

--- a/src/test/java/org/passay/PasswordValidatorTest.java
+++ b/src/test/java/org/passay/PasswordValidatorTest.java
@@ -588,10 +588,6 @@ public class PasswordValidatorTest extends AbstractRuleTest
             EnglishCharacterData.UpperCase.getErrorCode(),
             EnglishSequenceData.Numerical.getErrorCode(),
             EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode(),
-            EnglishSequenceData.Numerical.getErrorCode(),
             LengthRule.ERROR_CODE_MIN),
         },
       };


### PR DESCRIPTION
Rewrote IllegalSequenceRule to be much shorter and more efficient.

Other than the refactor, the functionality has also changed in one respect: if the illegal sequence length is set to e.g. 5 numerals, and the input password contains the sequence 1234567, then the new implementation will return the full illegal sequence 1234567 in the error result whereas the old implementation would return 3 illegal sequences 12345, 23456, 34567 (and not the full illegal sequence).

While it would be easy to support the previous functionality also after the refactor, I think the new behavior is more intuitive and informative, and the previously returned multiple subsequences, while technically correct, are not as useful (of course for every invalid sequence all subsequences of the configured length are also invalid... but the main sequence is the more interesting one to know about, which the old implementation misses.)

Also updated the tests for the new behavior, and added a few more interesting cases to the tests.