### PR TITLE
Add ArraySorter.sort default method to replace multiple implementations.

### DIFF
--- a/src/main/java/org/passay/dictionary/sort/ArraySorter.java
+++ b/src/main/java/org/passay/dictionary/sort/ArraySorter.java
@@ -2,6 +2,7 @@
 package org.passay.dictionary.sort;
 
 import java.util.Comparator;
+import org.passay.dictionary.WordLists;
 
 /**
  * Interface for array sort implementations.
@@ -11,13 +12,15 @@ import java.util.Comparator;
 public interface ArraySorter
 {
 
-
   /**
    * This will sort the supplied string array.
    *
    * @param  array  To sort
    */
-  void sort(String[] array);
+  default void sort(final String[] array)
+  {
+    sort(array, WordLists.CASE_SENSITIVE_COMPARATOR);
+  }
 
 
   /**

--- a/src/main/java/org/passay/dictionary/sort/ArraysSort.java
+++ b/src/main/java/org/passay/dictionary/sort/ArraysSort.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 public class ArraysSort implements ArraySorter
 {
 
-
   @Override
   public void sort(final String[] array)
   {

--- a/src/main/java/org/passay/dictionary/sort/BubbleSort.java
+++ b/src/main/java/org/passay/dictionary/sort/BubbleSort.java
@@ -2,7 +2,6 @@
 package org.passay.dictionary.sort;
 
 import java.util.Comparator;
-import org.passay.dictionary.WordLists;
 
 /**
  * Provides an implementation of the bubble sort algorithm.
@@ -11,14 +10,6 @@ import org.passay.dictionary.WordLists;
  */
 public class BubbleSort implements ArraySorter
 {
-
-
-  @Override
-  public void sort(final String[] array)
-  {
-    sort(array, WordLists.CASE_SENSITIVE_COMPARATOR);
-  }
-
 
   @Override
   public void sort(final String[] array, final Comparator<String> c)

--- a/src/main/java/org/passay/dictionary/sort/InsertionSort.java
+++ b/src/main/java/org/passay/dictionary/sort/InsertionSort.java
@@ -2,7 +2,6 @@
 package org.passay.dictionary.sort;
 
 import java.util.Comparator;
-import org.passay.dictionary.WordLists;
 
 /**
  * Provides an implementation of the insertion sort algorithm.
@@ -11,14 +10,6 @@ import org.passay.dictionary.WordLists;
  */
 public class InsertionSort implements ArraySorter
 {
-
-
-  @Override
-  public void sort(final String[] array)
-  {
-    sort(array, WordLists.CASE_SENSITIVE_COMPARATOR);
-  }
-
 
   @Override
   public void sort(final String[] array, final Comparator<String> c)

--- a/src/main/java/org/passay/dictionary/sort/QuickSort.java
+++ b/src/main/java/org/passay/dictionary/sort/QuickSort.java
@@ -2,7 +2,6 @@
 package org.passay.dictionary.sort;
 
 import java.util.Comparator;
-import org.passay.dictionary.WordLists;
 
 /**
  * Provides an implementation of the quick sort algorithm.
@@ -11,14 +10,6 @@ import org.passay.dictionary.WordLists;
  */
 public class QuickSort implements ArraySorter
 {
-
-
-  @Override
-  public void sort(final String[] array)
-  {
-    sort(array, WordLists.CASE_SENSITIVE_COMPARATOR);
-  }
-
 
   @Override
   public void sort(final String[] array, final Comparator<String> c)

--- a/src/main/java/org/passay/dictionary/sort/SelectionSort.java
+++ b/src/main/java/org/passay/dictionary/sort/SelectionSort.java
@@ -2,7 +2,6 @@
 package org.passay.dictionary.sort;
 
 import java.util.Comparator;
-import org.passay.dictionary.WordLists;
 
 /**
  * Provides an implementation of the selection sort algorithm.
@@ -11,14 +10,6 @@ import org.passay.dictionary.WordLists;
  */
 public class SelectionSort implements ArraySorter
 {
-
-
-  @Override
-  public void sort(final String[] array)
-  {
-    sort(array, WordLists.CASE_SENSITIVE_COMPARATOR);
-  }
-
 
   @Override
   public void sort(final String[] array, final Comparator<String> c)

--- a/src/test/java/org/passay/dictionary/sort/SorterTest.java
+++ b/src/test/java/org/passay/dictionary/sort/SorterTest.java
@@ -55,7 +55,7 @@ public class SorterTest
     final String[] array = TestUtil.fileToArray(dict);
     AssertJUnit.assertFalse(Arrays.equals(sortedArray, array));
     doSort(new BubbleSort(), array);
-    AssertJUnit.assertTrue(Arrays.equals(sortedArray, array));
+    AssertJUnit.assertArrayEquals(array, sortedArray);
   }
 
 
@@ -71,7 +71,7 @@ public class SorterTest
     final String[] array = TestUtil.fileToArray(dict);
     AssertJUnit.assertFalse(Arrays.equals(sortedArray, array));
     doSort(new ArraysSort(), array);
-    AssertJUnit.assertTrue(Arrays.equals(sortedArray, array));
+    AssertJUnit.assertArrayEquals(array, sortedArray);
   }
 
 
@@ -87,7 +87,7 @@ public class SorterTest
     final String[] array = TestUtil.fileToArray(dict);
     AssertJUnit.assertFalse(Arrays.equals(sortedArray, array));
     doSort(new InsertionSort(), array);
-    AssertJUnit.assertTrue(Arrays.equals(sortedArray, array));
+    AssertJUnit.assertArrayEquals(array, sortedArray);
   }
 
 
@@ -103,7 +103,7 @@ public class SorterTest
     final String[] array = TestUtil.fileToArray(dict);
     AssertJUnit.assertFalse(Arrays.equals(sortedArray, array));
     doSort(new QuickSort(), array);
-    AssertJUnit.assertTrue(Arrays.equals(sortedArray, array));
+    AssertJUnit.assertArrayEquals(array, sortedArray);
   }
 
 
@@ -119,7 +119,7 @@ public class SorterTest
     final String[] array = TestUtil.fileToArray(dict);
     AssertJUnit.assertFalse(Arrays.equals(sortedArray, array));
     doSort(new SelectionSort(), array);
-    AssertJUnit.assertTrue(Arrays.equals(sortedArray, array));
+    AssertJUnit.assertArrayEquals(array, sortedArray);
   }
 
 


### PR DESCRIPTION
The build currently fails due to the japicmp plugin (even though it should be backward-compatible), so you can merge this when you're ready for a major version bump or whatever the policy for introducing such changes is.