### PR TITLE
Fix NoSuchMethodErrors using Buffer when compiling on JDK9+

### DIFF
--- a/.travis/docker-run
+++ b/.travis/docker-run
@@ -3,7 +3,7 @@
 # Exit with nonzero exit code if anything fails
 set -e
 
-DOCKER_IMAGE="maven:3.6.0-jdk-8"
+DOCKER_IMAGE="maven:3.6.0-jdk-11"
 DOCKER_VOLUME="/apps/src"
 DOCKER_ENV="$DOCKER_ENV -e TRAVIS_PULL_REQUEST"
 DOCKER_ENV="$DOCKER_ENV -e TRAVIS_TAG"

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -2,6 +2,7 @@
 package org.passay;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -78,7 +79,8 @@ public class PasswordGenerator
       }
     }
     fillRandomCharacters(allChars, length - buffer.position(), buffer);
-    buffer.flip();
+    // cast to Buffer prevents NoSuchMethodError when compiled on JDK9+ and run on JDK8
+    ((Buffer) buffer).flip();
     randomize(buffer);
     return buffer.toString();
   }

--- a/src/main/java/org/passay/dictionary/AbstractFileWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractFileWordList.java
@@ -3,6 +3,7 @@ package org.passay.dictionary;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.LongBuffer;
@@ -189,7 +190,8 @@ public abstract class AbstractFileWordList extends AbstractWordList
    */
   private FileWord readNextWord() throws IOException
   {
-    wordBuf.clear();
+    // casts to Buffer below prevent NoSuchMethodError when compiled on JDK9+ and run on JDK8
+    ((Buffer) wordBuf).clear();
     long start = position;
     while (hasRemaining()) {
       final byte b = buffer().get();
@@ -208,13 +210,14 @@ public abstract class AbstractFileWordList extends AbstractWordList
       return null;
     }
 
-    charBuf.clear();
-    wordBuf.flip();
+    ((Buffer) charBuf).clear();
+    ((Buffer) wordBuf).flip();
     final CoderResult result = charsetDecoder.decode(wordBuf, charBuf, true);
     if (result.isError()) {
       result.throwException();
     }
-    return new FileWord(charBuf.flip().toString(), start);
+    ((Buffer) charBuf).flip();
+    return new FileWord(charBuf.toString(), start);
   }
 
 
@@ -408,7 +411,8 @@ public abstract class AbstractFileWordList extends AbstractWordList
       final LongBuffer temp = allocateDirect ?
         ByteBuffer.allocateDirect((int) size).asLongBuffer() : ByteBuffer.allocate((int) size).asLongBuffer();
       if (map != null) {
-        map.rewind();
+        // cast to Buffer prevents NoSuchMethodError when compiled on JDK9+ and run on JDK8
+        ((Buffer) map).rewind();
         temp.put(map);
       }
       map = temp;

--- a/src/main/java/org/passay/dictionary/FileWordList.java
+++ b/src/main/java/org/passay/dictionary/FileWordList.java
@@ -3,6 +3,7 @@ package org.passay.dictionary;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
@@ -22,8 +23,9 @@ public class FileWordList extends AbstractFileWordList
   /** Read buffer. */
   private final byte[] bytes = new byte[READ_BUFSIZE];
 
+  // we declare Buffer rather than ByteBuffer to prevent NoSuchMethodError when compiled on JDK9+ and run on JDK8
   /** Wrapper around read buffer. */
-  private final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+  private final Buffer buffer = ByteBuffer.wrap(bytes);
 
 
   /**
@@ -140,7 +142,7 @@ public class FileWordList extends AbstractFileWordList
   @Override
   protected ByteBuffer buffer()
   {
-    return buffer;
+    return (ByteBuffer) buffer;
   }
 
 

--- a/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
+++ b/src/main/java/org/passay/dictionary/MemoryMappedFileWordList.java
@@ -3,6 +3,7 @@ package org.passay.dictionary;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -20,8 +21,9 @@ import java.nio.charset.StandardCharsets;
 public class MemoryMappedFileWordList extends AbstractFileWordList
 {
 
+  // we declare Buffer rather than MappedByteBuffer to prevent NoSuchMethodError when compiled on JDK9+ and run on JDK8
   /** Memory-mapped buffer around file. */
-  private final MappedByteBuffer buffer;
+  private final Buffer buffer;
 
 
   /**
@@ -138,7 +140,7 @@ public class MemoryMappedFileWordList extends AbstractFileWordList
   @Override
   protected ByteBuffer buffer()
   {
-    return buffer;
+    return (ByteBuffer) buffer;
   }
 
 


### PR DESCRIPTION
and running on JDK 8.

I see you just reverted the JDK upgrade due to these Buffer API changes causing trouble... I hope this fixes it and you can proceed with the upgrade. Would be a shame to be stuck on JDK8...

btw, to recreate the issue without this fix, build (mvn clean install) using JDK 9+ (just specify a JAVA_HOME pointing to it), and then run the tests without compiling (mvn surefire:test) using JDK8.