### PR TITLE
Added keyboard sequence for german QWERTZ layout.

### DIFF
--- a/src/main/java/org/passay/GermanSequenceData.java
+++ b/src/main/java/org/passay/GermanSequenceData.java
@@ -13,10 +13,36 @@ public enum GermanSequenceData implements SequenceData
    * Alphabetical sequence.
    */
   Alphabetical(
-      "ILLEGAL_ALPHABETICAL_SEQUENCE",
-      new CharacterSequence[] {
-        new CharacterSequence("abcdefghijklmnopqrstuvwxyzäöüß", "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜẞ"),
-      });
+    "ILLEGAL_ALPHABETICAL_SEQUENCE",
+    new CharacterSequence[]{
+      new CharacterSequence("abcdefghijklmnopqrstuvwxyzäöüß", "ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜẞ"),
+    }),
+
+  /**
+   * German QWERTZ keyboard sequence.
+   */
+  GermanQwertz(
+    "ILLEGAL_QWERTY_SEQUENCE",
+    // rows are no-modifier, shift, alt-gr
+    // dead keys are denoted with the null character /u0000
+    new CharacterSequence[]{
+      new CharacterSequence(
+        "^1234567890\\´",
+        "°!\"§$%&/()=?`",
+        "\u0000\u0000²³\u0000\u0000\u0000{[]}\\\u0000"),
+      new CharacterSequence(
+        "qwertzuiopü+",
+        "QWERTZUIOPÜ*",
+        "@\u0000€\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000~"),
+      new CharacterSequence(
+        "asdfghjklöä#",
+        "ASDFGHJKLÖÄ'",
+        "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"),
+      new CharacterSequence(
+        "<yxcvbnm,.-",
+        ">YXCVBNM;:_",
+        "|\u0000\u0000\u0000\u0000\u0000\u0000µ\u0000\u0000\u0000"),
+    });
 
   /**
    * Error code.

--- a/src/test/java/org/passay/IllegalSequenceRuleTest.java
+++ b/src/test/java/org/passay/IllegalSequenceRuleTest.java
@@ -143,6 +143,33 @@ public class IllegalSequenceRuleTest extends AbstractRuleTest
           new PasswordData("pqwertyui#n65"),
           codes(EnglishSequenceData.USQwerty.getErrorCode()),
         },
+
+        /* German QWERTZ SEQUENCE */
+        // Test valid password
+        {
+          new IllegalSequenceRule(GermanSequenceData.GermanQwertz),
+          new PasswordData("p4zRcv8#n65"),
+          null,
+        },
+        // Has one 6 character qwertz sequence
+        {
+          new IllegalSequenceRule(GermanSequenceData.GermanQwertz, 6, false),
+          new PasswordData("pqwertz#n65"),
+          codes(GermanSequenceData.GermanQwertz.getErrorCode()),
+        },
+        // Has two 5 character qwertz sequences
+        {
+          new IllegalSequenceRule(GermanSequenceData.GermanQwertz, 5, false),
+          new PasswordData("wertz#~yxcvb"),
+          codes(GermanSequenceData.GermanQwertz.getErrorCode(), GermanSequenceData.GermanQwertz.getErrorCode()),
+        },
+        // Has one 4 character backward qwertz sequence
+        {
+          new IllegalSequenceRule(GermanSequenceData.GermanQwertz, 4, false),
+          new PasswordData("1xäölk2y"),
+          codes(GermanSequenceData.GermanQwertz.getErrorCode()),
+        },
+
         /* ALPHABETICAL SEQUENCE */
         // Test valid password
         {


### PR DESCRIPTION
I have added the keyboard sequence for the standard german keyboard layout, where y and z (and some other special characters) are placed differently compared to the english layout. I did not copy the full tests, that are made for USQwerty, but this is not necessary - the functionality does not depend on the layout itself.

I was unsure about the naming - you may also name the enum entry "DEQwertz", if the focus is on ISO **country** codes and not language codes. "DE" would be the correct ISO 3166 Alpha-2 country code for Germany. In the long run, this would be correct, because e.g. Switzerland has a slightly different keyboard layout, than Germany.