### PR TITLE
Avoid PatternSyntaxException formatting a regex.

### DIFF
--- a/src/main/java/org/passay/RepeatCharacterRegexRule.java
+++ b/src/main/java/org/passay/RepeatCharacterRegexRule.java
@@ -1,6 +1,8 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay;
 
+import java.util.Locale;
+
 /**
  * Rule for determining if a password contains a duplicate ASCII keyboard sequence. See {@link java.util.regex.Pattern}
  * /p{ASCII}. The default sequence length is 5 characters.
@@ -53,7 +55,7 @@ public class RepeatCharacterRegexRule extends IllegalRegexRule
    */
   public RepeatCharacterRegexRule(final int sl, final boolean reportAll)
   {
-    super(String.format(REPEAT_CHAR_REGEX, sl - 1), reportAll);
+    super(String.format(Locale.ENGLISH, REPEAT_CHAR_REGEX, sl - 1), reportAll);
     if (sl < MINIMUM_SEQUENCE_LENGTH) {
       throw new IllegalArgumentException(String.format("sequence length must be >= %s", MINIMUM_SEQUENCE_LENGTH));
     }

--- a/src/test/java/org/passay/RepeatCharacterRegexRuleTest.java
+++ b/src/test/java/org/passay/RepeatCharacterRegexRuleTest.java
@@ -1,7 +1,9 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay;
 
+import java.util.Locale;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 /**
  * Unit test for {@link RepeatCharacterRegexRule}.
@@ -112,5 +114,29 @@ public class RepeatCharacterRegexRuleTest extends AbstractRuleTest
             String.format("Password matches the illegal pattern '%s'.", "FFFFF"), },
         },
       };
+  }
+
+
+  /**
+   * Test with an arabic default locale.
+   */
+  @Test(groups = "passtest")
+  public void arabicLocale()
+  {
+    // Get the current default Locale
+    final Locale defaultLocale = Locale.getDefault();
+    try {
+      // Set the default Locale to ar-US
+      final Locale arUS = new Locale.Builder()
+        .setLanguage("ar")
+        .setRegion("US")
+        .build();
+      Locale.setDefault(arUS);
+
+      // In this Locale, the generated regular expression includes a repetition count that is non-ASCII
+      new RepeatCharacterRegexRule();
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 }


### PR DESCRIPTION
RepeatCharacterRegexRule uses String#format to create a regular expression. That operation is problematic in non-english locales. Define a specific locale for the operation.
Fixes #134.