### PR TITLE
Add missing Polish characters: ł, ń

### DIFF
--- a/src/main/java/org/passay/PolishCharacterData.java
+++ b/src/main/java/org/passay/PolishCharacterData.java
@@ -9,10 +9,10 @@ package org.passay;
 public enum  PolishCharacterData implements CharacterData {
 
   /** Lower case characters. */
-  LowerCase("INSUFFICIENT_LOWERCASE", "aąbcćdeęfghijklmnoópqrsśtuvwxyzźż"),
+  LowerCase("INSUFFICIENT_LOWERCASE", "aąbcćdeęfghijklłmnńoópqrsśtuvwxyzźż"),
 
   /** Upper case characters. */
-  UpperCase("INSUFFICIENT_UPPERCASE", "AĄBCĆDEĘFGHIJKLMNOÓPQRSŚTUVWXYZŹŻ");
+  UpperCase("INSUFFICIENT_UPPERCASE", "AĄBCĆDEĘFGHIJKLŁMNŃOÓPQRSŚTUVWXYZŹŻ");
 
   /** Error code. */
   private final String errorCode;

--- a/src/main/java/org/passay/PolishSequenceData.java
+++ b/src/main/java/org/passay/PolishSequenceData.java
@@ -12,7 +12,7 @@ public enum PolishSequenceData implements SequenceData {
   Alphabetical(
     "ILLEGAL_ALPHABETICAL_SEQUENCE",
     new CharacterSequence[] {
-      new CharacterSequence("aąbcćdeęfghijklmnoópqrsśtuwxyzźż", "AĄBCĆDEĘFGHIJKLMNOÓPQRSŚTUWXYZŹŻ"),
+      new CharacterSequence("aąbcćdeęfghijklłmnńoópqrsśtuwxyzźż", "AĄBCĆDEĘFGHIJKLŁMNŃOÓPQRSŚTUWXYZŹŻ"),
     });
 
   /** Error code. */


### PR DESCRIPTION
Fix the lack of `ł` and `ń` characters in PolishCharacterData and PolishSequenceData. Check [alphabet](https://en.wikipedia.org/wiki/Polish_alphabet) in case of doubts.