### PR TITLE
Adds HaveIveBeenPwndRule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <argLine>-Xms128m -Xmx1g</argLine>
+          <argLine>-Xms128m -Xmx1g -Duser.language=en</argLine>
           <suiteXmlFiles>
             <suiteXmlFile>${testng.dir}/testng.xml</suiteXmlFile>
           </suiteXmlFiles>

--- a/src/main/java/org/passay/HaveIveBeenPwndRule.java
+++ b/src/main/java/org/passay/HaveIveBeenPwndRule.java
@@ -1,0 +1,196 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Validates if the password against the online database of <code>haveivebeenpwnd.org</code>
+ * optionally allowing the usage of found passwords, but returns the number of found matches in
+ * the metadata.
+ *
+ * @author Wolfgang Jung (post@wolfgang-jung.net)
+ */
+public class HaveIveBeenPwndRule implements Rule
+{
+  /**
+   * Error code for known passwords.
+   */
+  public static final String ERROR_CODE = "HAVEIVEBEENPWND_ERROR";
+
+  /**
+   * number of chars to use from the SHA1 digest for the api call.
+   */
+  private static final int PREFIX_LENGTH = 5;
+
+  /**
+   * Name of the app.
+   */
+  private final String applicationName;
+
+  /**
+   * Address of the API
+   */
+  private URL remoteAddress;
+
+  /**
+   * Does a negative result (password known) from the API
+   * invalidating the password.
+   */
+  private boolean mandatory = true;
+
+  /**
+   * Maximum waiting time for connection and reading.
+   */
+  private Duration timeout;
+
+  /**
+   * Should passwords be allowed, if the API is inaccessible.
+   */
+  private boolean allowPasswordDuringTimeout = true;
+
+  /**
+   * Create the rule, appName is required by the
+   * <a href="https://haveibeenpwned.com/API/v3#UserAgent">API</a>.
+   *
+   * @param appName must not be null
+   */
+  public HaveIveBeenPwndRule(final String appName)
+  {
+    if (appName == null) {
+      throw new IllegalArgumentException("appName must be set");
+    }
+    this.applicationName = appName;
+    try {
+      remoteAddress = new URL("https://api.pwnedpasswords.com/range/");
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * Is the check mandatory.
+   *
+   * @param mandatoryCheck true: the rule does not allow previously pwnd passwords,
+   *                       false: pwnd passwords are allowed, but the number of matches is returned in the result.
+   */
+  public void setMandatory(final boolean mandatoryCheck)
+  {
+    this.mandatory = mandatoryCheck;
+  }
+
+  /**
+   * Set the API-Endpoint to a different server than <code>https://api.pwnedpasswords.com/range/</code>, e.g. in
+   * self-hosted environments.
+   *
+   * @param address the URL must end with a <code>/</code>.
+   */
+  public void setRemoteAddress(final URL address)
+  {
+    if (!address.getPath().endsWith("/")) {
+      throw new IllegalArgumentException("remoteAddress must end with /");
+    }
+    this.remoteAddress = address;
+  }
+
+  /**
+   * maximum Duration for connecting or reading from the API, defaults to the system defaults.
+   *
+   * @param duration null for system default.
+   */
+  public void setTimeout(final Duration duration)
+  {
+    this.timeout = duration;
+  }
+
+  /**
+   * If a timeout occurs during accessing the api, the password will be allowed, if set to true.
+   *
+   * @param allow true: if the API is not accessible, any password is accepted.
+   *              false: Default, API must answer in time to allow the password.
+   */
+  public void setAllowPasswordDuringTimeout(final boolean allow)
+  {
+    this.allowPasswordDuringTimeout = allow;
+  }
+
+  @Override
+  public RuleResult validate(final PasswordData passwordData)
+  {
+    final String hexDigest = getHexDigest(passwordData);
+    try (LineNumberReader lnr = openApiConnectionForRange(hexDigest.substring(0, PREFIX_LENGTH))) {
+      return searchResponse(hexDigest, lnr);
+    } catch (IOException e) {
+      return new RuleResult(allowPasswordDuringTimeout,
+        new RuleResultDetail(ERROR_CODE, Collections.singletonMap("count", 0)),
+        new RuleResultMetadata(RuleResultMetadata.CountCategory.Pwnd, 0));
+    }
+  }
+
+  private RuleResult searchResponse(final String hexDigest, final LineNumberReader lnr) throws IOException
+  {
+    String line;
+    final Pattern p = Pattern.compile("^(" + hexDigest.substring(PREFIX_LENGTH) + "):(\\d+)\\s*$");
+    while ((line = lnr.readLine()) != null) {
+      final Matcher m = p.matcher(line);
+      if (m.matches()) {
+        final int matchCount = Integer.parseInt(m.group(2));
+        return new RuleResult(!this.mandatory,
+          new RuleResultDetail(ERROR_CODE, Collections.singletonMap("count", matchCount)),
+          new RuleResultMetadata(RuleResultMetadata.CountCategory.Pwnd, matchCount));
+      }
+    }
+    return new RuleResult(true);
+  }
+
+  private static String toHexString(final byte[] digest)
+  {
+    final StringBuilder sb = new StringBuilder(40);
+    for (int i = 0; i < digest.length; i++) {
+      sb.append(String.format("%02x", digest[i]));
+    }
+    return sb.toString();
+  }
+
+  private static String getHexDigest(final PasswordData passwordData)
+  {
+    final String hexDigest;
+    try {
+      final MessageDigest md = MessageDigest.getInstance("SHA1");
+      final byte[] digest = md.digest(passwordData.getPassword().getBytes(Charset.defaultCharset()));
+      hexDigest = toHexString(digest).toUpperCase();
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("SHA1 not accessible", e);
+    }
+    return hexDigest;
+  }
+
+  private LineNumberReader openApiConnectionForRange(final String range) throws IOException
+  {
+    final URL url = new URL(remoteAddress, range);
+    final URLConnection c = url.openConnection();
+    c.setRequestProperty("User-Agent", applicationName);
+    if (timeout != null) {
+      c.setReadTimeout((int) timeout.toMillis());
+      c.setConnectTimeout((int) timeout.toMillis());
+    }
+    c.connect();
+
+    return new LineNumberReader(
+      new InputStreamReader(
+        c.getInputStream(),
+        StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/org/passay/RuleResultMetadata.java
+++ b/src/main/java/org/passay/RuleResultMetadata.java
@@ -38,7 +38,10 @@ public class RuleResultMetadata
     Allowed,
 
     /** illegal characters. */
-    Illegal;
+    Illegal,
+
+    /** Already leaked password. */
+    Pwnd;
 
 
     /**

--- a/src/main/resources/passay.properties
+++ b/src/main/resources/passay.properties
@@ -27,3 +27,4 @@ SOURCE_VIOLATION=Password cannot be the same as your %1$s password.
 TOO_LONG=Password must be no more than %2$s characters in length.
 TOO_SHORT=Password must be %1$s or more characters in length.
 TOO_MANY_OCCURRENCES=Password contains %2$s occurrences of the character '%1$s', but at most %3$s are allowed.
+HAVEIVEBEENPWND_ERROR=Password is known from previous leaks, seen %1$s times before. Consider this password as broken.

--- a/src/test/java/org/passay/HaveIveBeenPwndRuleTest.java
+++ b/src/test/java/org/passay/HaveIveBeenPwndRuleTest.java
@@ -1,0 +1,71 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test the HaveIveBeenPwnd Rule.
+ *
+ * @author Wolfgang Jung (post@wolfgang-jung.net)
+ */
+public class HaveIveBeenPwndRuleTest
+{
+  /**
+   * a common password, that is listed.
+   */
+  private static final String COMMON_PASSWORD = "trustno1";
+
+  @Test
+  public void testWithCommonPwd() throws MalformedURLException
+  {
+    final HaveIveBeenPwndRule pwndRule = new HaveIveBeenPwndRule("org.passay");
+    pwndRule.setRemoteAddress(new URL("https://api.pwnedpasswords.com/range/"));
+    pwndRule.setMandatory(true);
+    pwndRule.setTimeout(Duration.ofSeconds(10));
+    pwndRule.setAllowPasswordDuringTimeout(false);
+    final PasswordValidator validator = new PasswordValidator(pwndRule);
+    final RuleResult result = validator.validate(new PasswordData(COMMON_PASSWORD));
+    Assert.assertFalse(result.valid);
+    Assert.assertTrue(result.metadata.getCount(RuleResultMetadata.CountCategory.Pwnd) > 1);
+    Assert.assertEquals(validator.getMessages(result).size(), 1);
+    Assert.assertTrue(validator.getMessages(result).get(0).contains("previous leaks"));
+  }
+
+  @Test
+  public void testWithCommonPwdAndTooShortTimeout()
+  {
+    final HaveIveBeenPwndRule pwndRule = new HaveIveBeenPwndRule("org.passay");
+    pwndRule.setTimeout(Duration.ofMillis(1));
+    final RuleResult result = pwndRule.validate(new PasswordData(COMMON_PASSWORD));
+    Assert.assertTrue(result.valid);
+    Assert.assertEquals(result.metadata.getCount(RuleResultMetadata.CountCategory.Pwnd), 0);
+  }
+
+  @Test
+  public void testWithCommonPwdAndTooShortTimeoutNotAllowing()
+  {
+    final HaveIveBeenPwndRule pwndRule = new HaveIveBeenPwndRule("org.passay");
+    pwndRule.setTimeout(Duration.ofMillis(1));
+    pwndRule.setAllowPasswordDuringTimeout(false);
+    final RuleResult result = pwndRule.validate(new PasswordData(COMMON_PASSWORD));
+    Assert.assertFalse(result.valid);
+  }
+
+  @Test
+  public void testWithLongRandomPassword()
+  {
+    final HaveIveBeenPwndRule pwndRule = new HaveIveBeenPwndRule("org.passay");
+    final String s = new PasswordGenerator().generatePassword(64,
+      new CharacterRule(EnglishCharacterData.Special),
+      new CharacterRule(EnglishCharacterData.Alphabetical),
+      new CharacterRule(EnglishCharacterData.Digit)
+    );
+    final RuleResult result = pwndRule.validate(new PasswordData(s));
+    Assert.assertTrue(result.valid);
+  }
+}


### PR DESCRIPTION
- Added remote call to API
- configurable parameters: timeout, mandatory check, behaviour on timeouts
- Allow different endpoints
- Returns the number of found occurrences as `CountCategory.Pwnd`
- Adds `-Duser.language=en` to ensure working tests on non-english development platforms

fixes #146