### PR TITLE
fix: add missing 'ß' to GermanSequenceData

### DIFF
--- a/src/main/java/org/passay/GermanSequenceData.java
+++ b/src/main/java/org/passay/GermanSequenceData.java
@@ -27,7 +27,7 @@ public enum GermanSequenceData implements SequenceData
     // dead keys are denoted with the null character /u0000
     new CharacterSequence[]{
       new CharacterSequence(
-        "^1234567890\\´",
+        "^1234567890ß\\´",
         "°!\"§$%&/()=?`",
         "\u0000\u0000²³\u0000\u0000\u0000{[]}\\\u0000"),
       new CharacterSequence(


### PR DESCRIPTION
The 'ß' follows the '0' on the German keyboard layout