### PR TITLE
Relax PasswordGenerator API and add retry mech.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>org.passay</groupId>
   <artifactId>passay</artifactId>
   <packaging>jar</packaging>
-  <version>1.6.5-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
   <name>Passay Library</name>
   <description>Library for checking that a password complies with a custom set of rules</description>
   <url>https://www.passay.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>org.passay</groupId>
   <artifactId>passay</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.6.5-SNAPSHOT</version>
   <name>Passay Library</name>
   <description>Library for checking that a password complies with a custom set of rules</description>
   <url>https://www.passay.org</url>

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -64,8 +64,26 @@ public class PasswordGenerator
    * @param  rules  to generate compliant password from
    *
    * @return  generated password
+   *
+   * @deprecated use {@link #generatePassword(int, Rule[])}
    */
+  @Deprecated
   public String generatePassword(final int length, final CharacterRule... rules)
+  {
+    return generatePassword(length, Arrays.asList(rules));
+  }
+
+
+  /**
+   * See {@link #generatePassword(int, List)}.
+   *
+   * @param  <T>  type of rule
+   * @param  length  of password to generate
+   * @param  rules  to generate compliant password from
+   *
+   * @return  generated password
+   */
+  public <T extends Rule> String generatePassword(final int length, final T... rules)
   {
     return generatePassword(length, Arrays.asList(rules));
   }
@@ -80,7 +98,7 @@ public class PasswordGenerator
    *
    * @return  generated password
    */
-  public String generatePassword(final int length, final List<Rule> rules)
+  public String generatePassword(final int length, final List<? extends Rule> rules)
   {
     if (length <= 0) {
       throw new IllegalArgumentException("length must be greater than 0");

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -155,10 +155,4 @@ public class PasswordGenerator
       buffer.put(i, c);
     }
   }
-
-
-  private void validate(final String password, final List<Rule> rules)
-  {
-
-  }
 }


### PR DESCRIPTION
Relax generate API to accept a list of Rule so that rules that are naturally part of password validation can also be specified for password generation. The common use case is IllegalSequenceRule. Check the generated password against the given ruleset and try again up to 2 times to generate a valid password.

Resolves #152