### PR TITLE
v2: clear password data from memory

### DIFF
--- a/fuzz/run-compose
+++ b/fuzz/run-compose
@@ -3,4 +3,4 @@
 docker compose -f fuzz/docker-compose.yml down && \
   docker network prune -f && \
   docker compose -f fuzz/docker-compose.yml pull && \
-  docker compose -f fuzz/docker-compose.yml up --build --attach passay
+  docker compose -f fuzz/docker-compose.yml up --build --attach passay-fuzz

--- a/heap/Dockerfile
+++ b/heap/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 maven:3.9-amazoncorretto-17

--- a/heap/docker-compose.yml
+++ b/heap/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  passay-fuzz:
+  passay-heap:
     build: .
     volumes:
       - $HOME/.m2:/root/.m2
       - $PWD:/apps/passay
     command: >
       bash -c "export DEBIAN_FRONTEND=noninteractive &&
-      cd /apps/passay && fuzz/run"
+      cd /apps/passay && heap/run"

--- a/heap/pom.xml
+++ b/heap/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>passay-heap</artifactId>
+  <packaging>jar</packaging>
+  <name>PASSAY HEAP ANALYZE</name>
+  <description>Passay heap analyze</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.passay</groupId>
+      <artifactId>passay</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-depends</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+              <excludeArtifactIds>${project.artifactId}</excludeArtifactIds>
+              <outputDirectory>${basedir}/target/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/heap/run
+++ b/heap/run
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+HEAP_DUMP_FILE="target/HeapDump.hprof"
+
+mvn -Dcheckstyle.skip -DskipTests -Dmaven.javadoc.skip=true clean package dependency:copy-dependencies
+for i in target/*.jar; do
+  CLASSPATH=$CLASSPATH:$i
+done
+for i in target/dependency/*.jar; do
+  CLASSPATH=$CLASSPATH:$i
+done
+
+# don't perform garbage collection
+export JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+AlwaysPreTouch -Xms256m -Xmx256m"
+
+# create java heap dump
+java ${JAVA_OPTS} -cp ${CLASSPATH} org.passay.HeapDump ${HEAP_DUMP_FILE}

--- a/heap/run-compose
+++ b/heap/run-compose
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker compose -f heap/docker-compose.yml down && \
+  docker network prune -f && \
+  docker compose -f heap/docker-compose.yml pull && \
+  docker compose -f heap/docker-compose.yml up --build --attach passay-heap

--- a/src/main/java/org/passay/PassayUtils.java
+++ b/src/main/java/org/passay/PassayUtils.java
@@ -1,6 +1,13 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay;
 
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 /**
@@ -55,5 +62,98 @@ public final class PassayUtils
       throw new IllegalArgumentException(e);
     }
     return o;
+  }
+
+
+  /**
+   * Converts the supplied text to a byte array using the supplied charset.
+   *
+   * @param  text  to convert to a byte array
+   * @param  charset  to use for the conversion
+   *
+   * @return  encoded byte array
+   */
+  public static byte[] toByteArray(final CharSequence text, final Charset charset)
+  {
+    final ByteBuffer buffer = toByteBuffer(text, charset);
+    try {
+      final byte[] bytes = new byte[buffer.remaining()];
+      buffer.get(bytes);
+      return bytes;
+    } finally {
+      clear(buffer);
+    }
+  }
+
+
+  /**
+   * Converts the supplied text to a byte buffer using the supplied charset.
+   *
+   * @param  text  to convert to a byte array
+   * @param  charset  to use for the conversion
+   *
+   * @return  encoded byte buffer
+   */
+  private static ByteBuffer toByteBuffer(final CharSequence text, final Charset charset)
+  {
+    final char[] chars = new char[text.length()];
+    for (int i = 0; i < chars.length; i++) {
+      chars[i] = text.charAt(i);
+    }
+    final CharBuffer buffer = CharBuffer.wrap(chars);
+    try {
+      return charset.encode(buffer);
+    } finally {
+      clear(buffer);
+    }
+  }
+
+
+  /**
+   * Clears the supplied object by writing zeros to its data structure. The following types are supported:
+   * <ul>
+   *   <li>char[]</li>
+   *   <li>byte[]</li>
+   *   <li>int[]</li>
+   *   <li>long[]</li>
+   *   <li>CharBuffer</li>
+   *   <li>ByteBuffer</li>
+   *   <li>IntBuffer</li>
+   *   <li>LongBuffer</li>
+   * </ul>
+   *
+   * @param  o  to clear
+   *
+   * @throws  IllegalArgumentException  if the supplied object cannot be cleared
+   */
+  public static void clear(final Object o)
+  {
+    if (o instanceof char[]) {
+      Arrays.fill((char[]) o, '\u0000');
+    } else if (o instanceof byte[]) {
+      Arrays.fill((byte[]) o, (byte) 0);
+    } else if (o instanceof int[]) {
+      Arrays.fill((int[]) o, 0);
+    } else if (o instanceof long[]) {
+      Arrays.fill((long[]) o, 0L);
+    } else if (o instanceof Buffer) {
+      ((Buffer) o).rewind();
+      while (((Buffer) o).hasRemaining()) {
+        if (o instanceof CharBuffer) {
+          ((CharBuffer) o).put((char) 0);
+        } else if (o instanceof ByteBuffer) {
+          ((ByteBuffer) o).put((byte) 0);
+        } else if (o instanceof IntBuffer) {
+          ((IntBuffer) o).put(0);
+        } else if (o instanceof LongBuffer) {
+          ((LongBuffer) o).put(0L);
+        } else {
+          throw new IllegalArgumentException("Unsupported buffer type: " + o.getClass().getName());
+        }
+      }
+      ((Buffer) o).flip();
+    } else {
+      throw new IllegalArgumentException("Unsupported type: " + o.getClass().getName());
+    }
   }
 }

--- a/src/main/java/org/passay/PasswordData.java
+++ b/src/main/java/org/passay/PasswordData.java
@@ -1,6 +1,8 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay;
 
+import java.nio.Buffer;
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,10 +29,10 @@ public final class PasswordData
   }
 
   /** Stores the password. */
-  private final String password;
+  private final UnicodeString password;
 
   /** Stores the username. */
-  private final String username;
+  private final UnicodeString username;
 
   /** Password references. */
   private final List<Reference> passwordReferences = new ArrayList<>();
@@ -46,6 +48,17 @@ public final class PasswordData
    */
   public PasswordData(final String password)
   {
+    this(new UnicodeString(password));
+  }
+
+
+  /**
+   * Creates a new password data. The origin of this data is assumed to be {@link Origin#User} by default.
+   *
+   * @param  password  password
+   */
+  public PasswordData(final UnicodeString password)
+  {
     this(null, password, Origin.User, Collections.emptyList());
   }
 
@@ -58,6 +71,18 @@ public final class PasswordData
    */
   public PasswordData(final String username, final String password)
   {
+    this(new UnicodeString(username), new UnicodeString(password));
+  }
+
+
+  /**
+   * Creates a new password data. The origin of this data is assumed to be {@link Origin#User} by default.
+   *
+   * @param  username  username
+   * @param  password  password
+   */
+  public PasswordData(final UnicodeString username, final UnicodeString password)
+  {
     this(username, password, Origin.User, Collections.emptyList());
   }
 
@@ -69,6 +94,18 @@ public final class PasswordData
    * @param  origin  origin
    */
   public PasswordData(final String password, final Origin origin)
+  {
+    this(new UnicodeString(password), origin);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  password  password
+   * @param  origin  origin
+   */
+  public PasswordData(final UnicodeString password, final Origin origin)
   {
     this(null, password, origin, Collections.emptyList());
   }
@@ -83,6 +120,19 @@ public final class PasswordData
    */
   public PasswordData(final String username, final String password, final Origin origin)
   {
+    this(new UnicodeString(username), new UnicodeString(password), origin);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  username  username
+   * @param  password  password
+   * @param  origin  origin
+   */
+  public PasswordData(final UnicodeString username, final UnicodeString password, final Origin origin)
+  {
     this(username, password, origin, Collections.emptyList());
   }
 
@@ -96,6 +146,19 @@ public final class PasswordData
    */
   public PasswordData(final String username, final String password, final Reference... references)
   {
+    this(new UnicodeString(username), new UnicodeString(password), references);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  username  username
+   * @param  password  password
+   * @param  references  references
+   */
+  public PasswordData(final UnicodeString username, final UnicodeString password, final Reference... references)
+  {
     this(username, password, Origin.User, Arrays.asList(references));
   }
 
@@ -108,6 +171,19 @@ public final class PasswordData
    * @param  references  references
    */
   public PasswordData(final String username, final String password, final List<Reference> references)
+  {
+    this(new UnicodeString(username), new UnicodeString(password), references);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  username  username
+   * @param  password  password
+   * @param  references  references
+   */
+  public PasswordData(final UnicodeString username, final UnicodeString password, final List<Reference> references)
   {
     this(username, password, Origin.User, references);
   }
@@ -124,6 +200,21 @@ public final class PasswordData
   public PasswordData(
     final String username, final String password, final Origin origin, final Reference... references)
   {
+    this(new UnicodeString(username), new UnicodeString(password), origin, references);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  username  username
+   * @param  password  password
+   * @param  origin  origin
+   * @param  references  references
+   */
+  public PasswordData(
+    final UnicodeString username, final UnicodeString password, final Origin origin, final Reference... references)
+  {
     this(username, password, origin, Arrays.asList(references));
   }
 
@@ -138,6 +229,21 @@ public final class PasswordData
    */
   public PasswordData(
     final String username, final String password, final Origin origin, final List<Reference> references)
+  {
+    this(new UnicodeString(username), new UnicodeString(password), origin, references);
+  }
+
+
+  /**
+   * Creates a new password data.
+   *
+   * @param  username  username
+   * @param  password  password
+   * @param  origin  origin
+   * @param  references  references
+   */
+  public PasswordData(
+    final UnicodeString username, final UnicodeString password, final Origin origin, final List<Reference> references)
   {
     this.username = username;
     this.password = PassayUtils.assertNotNullArg(password, "Password cannot be null");
@@ -157,7 +263,7 @@ public final class PasswordData
    *
    * @return  password
    */
-  public String getPassword()
+  public UnicodeString getPassword()
   {
     return password;
   }
@@ -170,7 +276,7 @@ public final class PasswordData
    */
   public int getCharacterCount()
   {
-    return UnicodeString.charCount(password);
+    return password.length();
   }
 
 
@@ -190,7 +296,7 @@ public final class PasswordData
    *
    * @return  username
    */
-  public String getUsername()
+  public UnicodeString getUsername()
   {
     return username;
   }
@@ -225,11 +331,26 @@ public final class PasswordData
 
 
   /**
-   * Returns a password data initialized with the supplied data.
+   * Clears the memory of the underlying objects in this password data. See {@link UnicodeString#clear()}.
+   */
+  public void clear()
+  {
+    if (password != null) {
+      password.clear();
+    }
+    if (username != null) {
+      username.clear();
+    }
+    passwordReferences.forEach(Reference::clear);
+  }
+
+
+  /**
+   * Returns a new password data initialized with the supplied data.
    *
    * @param  data  password data to read properties from
    *
-   * @return  password data
+   * @return  new password data
    */
   public static PasswordData copy(final PasswordData data)
   {
@@ -262,7 +383,7 @@ public final class PasswordData
      * @param password the cleartext password to apply the salt to
      * @return the salted password
      */
-    String applyTo(String password);
+    CharBuffer applyTo(CharBuffer password);
   }
 
 
@@ -286,9 +407,12 @@ public final class PasswordData
     }
 
     @Override
-    public String applyTo(final String password)
+    public CharBuffer applyTo(final CharBuffer password)
     {
-      return salt + password;
+      final CharBuffer salted = CharBuffer.allocate(salt.length() + password.length());
+      salted.put(salt).put(password);
+      ((Buffer) salted).flip();
+      return salted;
     }
   }
 
@@ -313,9 +437,12 @@ public final class PasswordData
     }
 
     @Override
-    public String applyTo(final String password)
+    public CharBuffer applyTo(final CharBuffer password)
     {
-      return password + salt;
+      final CharBuffer salted = CharBuffer.allocate(salt.length() + password.length());
+      salted.put(password).put(salt);
+      ((Buffer) salted).flip();
+      return salted;
     }
   }
 
@@ -329,7 +456,14 @@ public final class PasswordData
      *
      * @return  password string
      */
-    String getPassword();
+    UnicodeString getPassword();
+
+
+    /**
+     * Clears the memory of the underlying objects in this reference.
+     */
+    void clear();
+
 
     /**
      * Returns the salt that was applied to the reference password before digesting it.
@@ -363,6 +497,17 @@ public final class PasswordData
     /**
      * Creates a new historical reference.
      *
+     * @param  password  password string
+     */
+    public HistoricalReference(final UnicodeString password)
+    {
+      super(null, password);
+    }
+
+
+    /**
+     * Creates a new historical reference.
+     *
      * @param  label  label for this password
      * @param  password  password string
      */
@@ -377,9 +522,34 @@ public final class PasswordData
      *
      * @param  label  label for this password
      * @param  password  password string
+     */
+    public HistoricalReference(final String label, final UnicodeString password)
+    {
+      super(label, password);
+    }
+
+
+    /**
+     * Creates a new historical reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
      * @param  salt  salt that was applied to password
      */
     public HistoricalReference(final String label, final String password, final Salt salt)
+    {
+      super(label, password, salt);
+    }
+
+
+    /**
+     * Creates a new historical reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     * @param  salt  salt that was applied to password
+     */
+    public HistoricalReference(final String label, final UnicodeString password, final Salt salt)
     {
       super(label, password, salt);
     }
@@ -405,10 +575,33 @@ public final class PasswordData
     /**
      * Creates a new source reference.
      *
+     * @param  password  password string
+     */
+    public SourceReference(final UnicodeString password)
+    {
+      super(null, password);
+    }
+
+
+    /**
+     * Creates a new source reference.
+     *
      * @param  label  label for this password
      * @param  password  password string
      */
     public SourceReference(final String label, final String password)
+    {
+      super(label, password);
+    }
+
+
+    /**
+     * Creates a new source reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     */
+    public SourceReference(final String label, final UnicodeString password)
     {
       super(label, password);
     }
@@ -425,6 +618,19 @@ public final class PasswordData
     {
       super(label, password, salt);
     }
+
+
+    /**
+     * Creates a new source reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     * @param  salt  salt that was applied to password
+     */
+    public SourceReference(final String label, final UnicodeString password, final Salt salt)
+    {
+      super(label, password, salt);
+    }
   }
 
 
@@ -436,25 +642,10 @@ public final class PasswordData
     private final String label;
 
     /** Reference password. */
-    private final String password;
+    private final UnicodeString password;
 
     /** Salt that was applied to reference password before digesting it. */
     private final Salt salt;
-
-
-    /**
-     * Creates a new abstract reference.
-     *
-     * @param  label  label for this password
-     * @param  password  password string
-     * @param  salt  salt that was applied to password
-     */
-    public AbstractReference(final String label, final String password, final Salt salt)
-    {
-      this.label = label;
-      this.password = password;
-      this.salt = salt;
-    }
 
 
     /**
@@ -470,6 +661,46 @@ public final class PasswordData
 
 
     /**
+     * Creates a new abstract reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     */
+    public AbstractReference(final String label, final UnicodeString password)
+    {
+      this(label, password, null);
+    }
+
+
+    /**
+     * Creates a new abstract reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     * @param  salt  salt that was applied to password
+     */
+    public AbstractReference(final String label, final String password, final Salt salt)
+    {
+      this(label, new UnicodeString(password), salt);
+    }
+
+
+    /**
+     * Creates a new abstract reference.
+     *
+     * @param  label  label for this password
+     * @param  password  password string
+     * @param  salt  salt that was applied to password
+     */
+    public AbstractReference(final String label, final UnicodeString password, final Salt salt)
+    {
+      this.label = label;
+      this.password = password;
+      this.salt = salt;
+    }
+
+
+    /**
      * Returns the label.
      *
      * @return  reference label
@@ -481,7 +712,7 @@ public final class PasswordData
 
 
     @Override
-    public String getPassword()
+    public UnicodeString getPassword()
     {
       return password;
     }
@@ -501,6 +732,15 @@ public final class PasswordData
         "label=" + label + ", " +
         "password=" + password + ", " +
         "salt=" + salt;
+    }
+
+
+    @Override
+    public void clear()
+    {
+      if (password != null) {
+        password.clear();
+      }
     }
   }
 }

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -74,7 +74,7 @@ public class PasswordGenerator
    * @return  generated password
    */
   @SuppressWarnings("unchecked")
-  public <T extends Rule> String generatePassword(final int length, final T... rules)
+  public <T extends Rule> UnicodeString generatePassword(final int length, final T... rules)
   {
     PassayUtils.assertNotNullArgOr(
       rules,
@@ -93,7 +93,7 @@ public class PasswordGenerator
    *
    * @return  generated password
    */
-  public String generatePassword(final int length, final List<? extends Rule> rules)
+  public UnicodeString generatePassword(final int length, final List<? extends Rule> rules)
   {
     if (length <= 0) {
       throw new IllegalArgumentException("Length must be greater than 0");
@@ -108,7 +108,7 @@ public class PasswordGenerator
 
     final StringBuilder allChars = new StringBuilder();
     final CharBuffer buffer = CharBuffer.allocate(length);
-    String generated;
+    UnicodeString generated;
     int count = 0;
 
     do {
@@ -128,19 +128,26 @@ public class PasswordGenerator
       // cast to Buffer prevents NoSuchMethodError when compiled on JDK9+ and run on JDK8
       ((Buffer) buffer).flip();
       randomize(buffer);
-      generated = buffer.toString();
+      generated = new UnicodeString(buffer);
       if (count > 0) {
         retryCount++;
       }
       final DefaultPasswordValidator validator = new DefaultPasswordValidator(rules);
       if (validator.validate(new PasswordData(generated)).isValid()) {
         break;
+      } else {
+        generated.clear();
       }
     } while (++count <= RETRY_LIMIT);
     if (count > RETRY_LIMIT) {
+      generated.clear();
       throw new IllegalStateException("Exceeded maximum number of password generation retries");
     }
-    return generated;
+    try {
+      return generated;
+    } finally {
+      PassayUtils.clear(buffer);
+    }
   }
 
 

--- a/src/main/java/org/passay/UnicodeString.java
+++ b/src/main/java/org/passay/UnicodeString.java
@@ -1,7 +1,10 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay;
 
+import java.nio.Buffer;
+import java.nio.CharBuffer;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 /**
@@ -17,40 +20,69 @@ public final class UnicodeString
 
 
   /**
-   * Creates a new code points.
+   * Creates a new unicode string.
    *
    * @param  chars  characters
    */
   public UnicodeString(final char... chars)
   {
-    this(new String(chars));
+    PassayUtils.assertNotNullArg(chars, "Chars cannot be null");
+    this.codePoints = new int[Character.codePointCount(chars, 0, chars.length)];
+    int i = 0;
+    int codePointsIndex = 0;
+    while (i < chars.length) {
+      final int cp = Character.codePointAt(chars, i);
+      this.codePoints[codePointsIndex++] = cp;
+      i += Character.charCount(cp);
+    }
   }
 
 
   /**
-   * Creates a new code points.
+   * Creates a new unicode string.
    *
-   * @param  string  characters
+   * @param  cs  character sequence
    */
-  public UnicodeString(final String string)
+  public UnicodeString(final CharSequence cs)
   {
-    PassayUtils.assertNotNullArgOr(string, String::isEmpty, "String cannot be null or have a length of zero");
-    codePoints = string.codePoints().toArray();
+    PassayUtils.assertNotNullArg(cs, "Char sequence cannot be null");
+    final int[] array = cs.codePoints().toArray();
+    try {
+      this.codePoints = Arrays.copyOf(array, array.length);
+    } finally {
+      PassayUtils.clear(array);
+    }
   }
 
 
   /**
-   * Creates a new code points.
+   * Creates a new unicode string.
    *
    * @param  codePoints  character code points
    */
   public UnicodeString(final int... codePoints)
   {
-    PassayUtils.assertNotNullArgOr(
-      codePoints,
-      v -> v.length == 0,
-      "Code points cannot be null or have a length of zero");
+    PassayUtils.assertNotNullArg(codePoints, "Code points cannot be null");
     this.codePoints = Arrays.copyOf(codePoints, codePoints.length);
+  }
+
+
+  /**
+   * Returns the code point at the supplied index.
+   *
+   * @param  index  of the code point
+   *
+   * @return  code point
+   */
+  public int codePointAt(final int index)
+  {
+    if (index < 0) {
+      throw new IllegalArgumentException("Index " + index + " must be greater than or equal to zero");
+    }
+    if (index >= codePoints.length) {
+      throw new IllegalArgumentException("Index " + index + " must be less than " + codePoints.length);
+    }
+    return codePoints[index];
   }
 
 
@@ -59,9 +91,69 @@ public final class UnicodeString
    *
    * @return  code points
    */
-  public int[] getCodePoints()
+  public int[] codePoints()
   {
     return Arrays.copyOf(codePoints, codePoints.length);
+  }
+
+
+  /**
+   * Returns a new unicode string with each character lower cased. See {@link Character#toLowerCase(int)}.
+   *
+   * @return  lower cased unicode string
+   */
+  public UnicodeString toLowerCase()
+  {
+    return toLowerCase(false);
+  }
+
+
+  /**
+   * Returns a new unicode string with each character lower cased. See {@link Character#toLowerCase(int)}.
+   *
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  lower cased unicode string
+   */
+  public UnicodeString toLowerCase(final boolean clear)
+  {
+    try {
+      return new UnicodeString(IntStream.of(codePoints).map(Character::toLowerCase).toArray());
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Returns a new unicode string with each character upper cased. See {@link Character#toUpperCase(int)}.
+   *
+   * @return  upper cased unicode string
+   */
+  public UnicodeString toUpperCase()
+  {
+    return toUpperCase(false);
+  }
+
+
+  /**
+   * Returns a new unicode string with each character upper cased. See {@link Character#toUpperCase(int)}.
+   *
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  upper cased unicode string
+   */
+  public UnicodeString toUpperCase(final boolean clear)
+  {
+    try {
+      return new UnicodeString(IntStream.of(codePoints).map(Character::toUpperCase).toArray());
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
   }
 
 
@@ -77,13 +169,299 @@ public final class UnicodeString
 
 
   /**
-   * Returns a new string containing the code points. See {@link #toString(int[])}.
+   * Returns whether this unicode string has any code points.
+   *
+   * @return  whether this unicode string has any code points
+   */
+  public boolean isEmpty()
+  {
+    return codePoints.length == 0;
+  }
+
+
+  /**
+   * Returns a new unicode string containing code points from the supplied begin index.
+   *
+   * @param  beginIndex  of the code point that would be the first code point in the new unicode string
+   *
+   * @return  new unicode substring
+   */
+  public UnicodeString substring(final int beginIndex)
+  {
+    return substring(beginIndex, codePoints.length);
+  }
+
+
+  /**
+   * Returns a new unicode string containing code points from the supplied begin index (inclusive) to the the supplied
+   * end index (exclusive).
+   *
+   * @param  beginIndex  of the code point that would be the first code point in the new unicode string
+   * @param  endIndex  of the code point that would be the last code point in the new unicode string
+   *
+   * @return  new unicode substring
+   */
+  public UnicodeString substring(final int beginIndex, final int endIndex)
+  {
+    if (beginIndex < 0) {
+      throw new IllegalArgumentException("Begin index cannot be negative");
+    }
+    if (beginIndex > endIndex) {
+      throw new IllegalArgumentException("Begin index cannot be greater than end index");
+    }
+    if (endIndex > codePoints.length) {
+      throw new IllegalArgumentException("End index cannot be greater than the number of code points");
+    }
+    if (beginIndex == 0 && endIndex == codePoints.length) {
+      return new UnicodeString(codePoints);
+    }
+    final int length = endIndex - beginIndex;
+    if (length == 0) {
+      return new UnicodeString();
+    }
+    return new UnicodeString(Arrays.copyOfRange(codePoints, beginIndex, beginIndex + length));
+  }
+
+
+  /**
+   * Returns a new unicode string with the code points reversed.
+   *
+   * @return  reversed unicode string
+   */
+  public UnicodeString reverse()
+  {
+    return reverse(false);
+  }
+
+
+  /**
+   * Returns a new unicode string with the code points reversed.
+   *
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  reversed unicode string
+   */
+  public UnicodeString reverse(final boolean clear)
+  {
+    try {
+      final int[] reversedCodePoints = new int[codePoints.length];
+      for (int i = 0; i < codePoints.length; i++) {
+        reversedCodePoints[i] = codePoints[codePoints.length - i - 1];
+      }
+      return new UnicodeString(reversedCodePoints);
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Writes zeros to the underlying code points array.
+   */
+  public void clear()
+  {
+    Arrays.fill(codePoints, 0);
+  }
+
+
+  /**
+   * Returns the number of characters in the supplied input that exist in this unicode string.
+   *
+   * @param  input  code points of characters to match
+   *
+   * @return  character count
+   */
+  public int countMatchingCharacters(final int[] input)
+  {
+    return (int) IntStream.of(codePoints).filter(x -> IntStream.of(input).anyMatch(y -> y == x)).count();
+  }
+
+
+  /**
+   * Returns whether this unicode string starts with the supplied prefix.
+   *
+   * @param  prefix  to compare with this unicode string
+   *
+   * @return  whether this unicode string starts with prefix
+   */
+  public boolean startsWith(final UnicodeString prefix)
+  {
+    return startsWith(prefix, 0);
+  }
+
+
+  /**
+   * Returns whether this unicode string starts with the supplied prefix at the supplied offset.
+   *
+   * @param  prefix  to compare with this unicode string
+   * @param  offset  code point index at which to compare the prefix
+   *
+   * @return  whether this unicode string starts with prefix at the offset
+   */
+  boolean startsWith(final UnicodeString prefix, final int offset)
+  {
+    final int[] prefixCodePoints = prefix.codePoints;
+    int i = 0;
+    int j = offset;
+    while (i < prefixCodePoints.length) {
+      if (prefixCodePoints[i++] != codePoints[j++]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+  /**
+   * Returns whether this unicode string ends with the supplied suffix.
+   *
+   * @param  suffix  to compare with this unicode string
+   *
+   * @return  whether this unicode string ends with suffix
+   */
+  public boolean endsWith(final UnicodeString suffix)
+  {
+    return startsWith(suffix, codePoints.length - suffix.length());
+  }
+
+
+  /**
+   * Returns whether this unicode string contains the supplied string.
+   *
+   * @param  other  to compare with this unicode string
+   *
+   * @return  whether this unicode string contains other
+   */
+  public boolean contains(final UnicodeString other)
+  {
+    return indexOf(other) >= 0;
+  }
+
+
+  /**
+   * Returns code point index in this unicode string of the supplied string.
+   *
+   * @param  other  to search this unicode string
+   *
+   * @return  the code point index of other in this unicdoe string
+   */
+  // CheckStyle:ReturnCount OFF
+  int indexOf(final UnicodeString other)
+  {
+    final int[] otherCodePoints = other.codePoints;
+    final int max = codePoints.length - otherCodePoints.length;
+    for (int i = 0; i <= max; i++) {
+      // search for the first code point
+      if (codePoints[i] != otherCodePoints[0]) {
+        do {
+          i++;
+        } while (i <= max && codePoints[i] != otherCodePoints[0]);
+      }
+      if (i <= max) {
+        // first code point matched, iterate through the remaining code points
+        int j = i + 1;
+        final int end = j + otherCodePoints.length - 1;
+        int k = 1;
+        while (j < end && codePoints[j] == otherCodePoints[k]) {
+          j++;
+          k++;
+        }
+        if (j == end) {
+          // all code points matched
+          return i;
+        }
+      }
+    }
+    // all code points did not match
+    return -1;
+  }
+  // CheckStyle:ReturnCount ON
+
+
+  /**
+   * Returns a new char buffer derived from the code points.
+   *
+   * @return  new char buffer
+   */
+  public CharBuffer toCharBuffer()
+  {
+    return toCharBuffer(false);
+  }
+
+
+  /**
+   * Returns a new char buffer derived from the code points.
+   *
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  new char buffer
+   */
+  public CharBuffer toCharBuffer(final boolean clear)
+  {
+    try {
+      final int capacity = IntStream.of(codePoints).map(Character::charCount).sum();
+      final CharBuffer buffer = CharBuffer.allocate(capacity);
+      for (int codePoint : codePoints) {
+        buffer.put(Character.toChars(codePoint));
+      }
+      ((Buffer) buffer).flip();
+      return buffer;
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Returns a string representation of the code points array in this unicode string. This method does not convert the
+   * code points to a {@link String}. See {@link #toString(UnicodeString)} to convert code points to a {@link String}.
    *
    * @return  new string
    */
+  @Override
   public String toString()
   {
-    return toString(codePoints);
+    return Arrays.toString(codePoints);
+  }
+
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof UnicodeString) {
+      final UnicodeString v = (UnicodeString) o;
+      return Arrays.equals(codePoints, v.codePoints);
+    }
+    return false;
+  }
+
+
+  @Override
+  public int hashCode()
+  {
+    // CheckStyle:MagicNumber OFF
+    return 31 * Objects.hashCode(codePoints);
+    // CheckStyle:MagicNumber ON
+  }
+
+
+  /**
+   * Creates a copy of the supplied unicode string.
+   *
+   * @param  string  to copy
+   *
+   * @return  new unicode string
+   */
+  public static UnicodeString copy(final UnicodeString string)
+  {
+    return new UnicodeString(string.codePoints);
   }
 
 
@@ -97,6 +475,19 @@ public final class UnicodeString
   public static int charCount(final String string)
   {
     return string != null ? string.codePointCount(0, string.length()) : 0;
+  }
+
+
+  /**
+   * Creates a new string from the supplied unicode string.
+   *
+   * @param  string  to create string from
+   *
+   * @return  new string
+   */
+  public static String toString(final UnicodeString string)
+  {
+    return toString(string.codePoints);
   }
 
 
@@ -123,33 +514,5 @@ public final class UnicodeString
   public static String toString(final int[] codePoints)
   {
     return new String(codePoints, 0, codePoints.length);
-  }
-
-
-  /**
-   * Returns the number of characters in the supplied input that existing from the supplied characters string.
-   *
-   * @param  codePoints  code points of characters to match
-   * @param  input  to search for matches
-   *
-   * @return  character count
-   */
-  public static int countMatchingCharacters(final int[] codePoints, final String input)
-  {
-    return (int) input.codePoints().filter(x -> IntStream.of(codePoints).anyMatch(y -> y == x)).count();
-  }
-
-
-  /**
-   * Returns the number of characters in the supplied input that existing from the supplied characters string.
-   *
-   * @param  characters  that contains characters to match
-   * @param  input  to search for matches
-   *
-   * @return  character count
-   */
-  public static int countMatchingCharacters(final String characters, final String input)
-  {
-    return (int) input.codePoints().filter(x -> characters.indexOf(x) != -1).count();
   }
 }

--- a/src/main/java/org/passay/dictionary/AbstractWordList.java
+++ b/src/main/java/org/passay/dictionary/AbstractWordList.java
@@ -14,11 +14,11 @@ public abstract class AbstractWordList implements WordList
 {
 
   /** Word comparator. */
-  protected Comparator<String> comparator;
+  protected Comparator<CharSequence> comparator;
 
 
   @Override
-  public Comparator<String> getComparator()
+  public Comparator<CharSequence> getComparator()
   {
     return comparator;
   }

--- a/src/main/java/org/passay/dictionary/BloomFilterDictionary.java
+++ b/src/main/java/org/passay/dictionary/BloomFilterDictionary.java
@@ -15,7 +15,7 @@ public class BloomFilterDictionary implements Dictionary
 {
 
   /** Filter used for searching. */
-  private final BloomFilter<String> bloomFilter;
+  private final BloomFilter<CharSequence> bloomFilter;
 
 
   /**
@@ -27,7 +27,7 @@ public class BloomFilterDictionary implements Dictionary
    *
    * @param  filter  bloom filter used to determine if a word exists.
    */
-  public BloomFilterDictionary(final BloomFilter<String> filter)
+  public BloomFilterDictionary(final BloomFilter<CharSequence> filter)
   {
     bloomFilter = PassayUtils.assertNotNullArg(filter, "Bloom filter cannot be null");
   }
@@ -38,7 +38,7 @@ public class BloomFilterDictionary implements Dictionary
    *
    * @return  bloom filter
    */
-  public BloomFilter<String> getBloomFilter()
+  public BloomFilter<CharSequence> getBloomFilter()
   {
     return bloomFilter;
   }
@@ -68,7 +68,7 @@ public class BloomFilterDictionary implements Dictionary
    * bloom filter
    */
   @Override
-  public boolean search(final String word)
+  public boolean search(final CharSequence word)
   {
     return bloomFilter.mightContain(word);
   }

--- a/src/main/java/org/passay/dictionary/Dictionary.java
+++ b/src/main/java/org/passay/dictionary/Dictionary.java
@@ -17,7 +17,7 @@ public interface Dictionary
    *
    * @return  whether word was found
    */
-  boolean search(String word);
+  boolean search(CharSequence word);
 
 
   /**

--- a/src/main/java/org/passay/dictionary/JDBCDictionary.java
+++ b/src/main/java/org/passay/dictionary/JDBCDictionary.java
@@ -42,7 +42,7 @@ public class JDBCDictionary implements Dictionary
 
 
   @Override
-  public boolean search(final String word)
+  public boolean search(final CharSequence word)
   {
     try {
       return executeStatement(searchStatement, String.class, word) != null;

--- a/src/main/java/org/passay/dictionary/TernaryTree.java
+++ b/src/main/java/org/passay/dictionary/TernaryTree.java
@@ -66,7 +66,7 @@ public class TernaryTree
    *
    * @param  word  to insert
    */
-  public void insert(final String word)
+  public void insert(final CharSequence word)
   {
     if (word != null) {
       root = insertNode(root, word, 0);
@@ -79,10 +79,10 @@ public class TernaryTree
    *
    * @param  words  to insert
    */
-  public void insert(final String[] words)
+  public void insert(final CharSequence[] words)
   {
     if (words != null) {
-      for (String s : words) {
+      for (CharSequence s : words) {
         insert(s);
       }
     }
@@ -96,9 +96,9 @@ public class TernaryTree
    *
    * @return  whether the word was found
    */
-  public boolean search(final String word)
+  public boolean search(final CharSequence word)
   {
-    return searchNode(root, word, 0);
+    return searchNode(root, word.codePoints().toArray(), 0);
   }
 
 
@@ -117,14 +117,14 @@ public class TernaryTree
    *
    * @throws  UnsupportedOperationException  if this is a case insensitive ternary tree
    */
-  public String[] partialSearch(final String word)
+  public CharSequence[] partialSearch(final CharSequence word)
   {
     if (comparator == CASE_INSENSITIVE_COMPARATOR) {
       throw new UnsupportedOperationException("Partial search is not supported for case insensitive ternary trees");
     }
 
-    final List<String> matches = partialSearchNode(root, null, "", word, 0);
-    return matches == null ? EMPTY_ARRAY : matches.toArray(new String[0]);
+    final List<CharSequence> matches = partialSearchNode(root, null, "", word, 0);
+    return matches == null ? EMPTY_ARRAY : matches.toArray(new CharSequence[0]);
   }
 
 
@@ -143,14 +143,14 @@ public class TernaryTree
    *
    * @throws  UnsupportedOperationException  if this is a case insensitive ternary tree
    */
-  public String[] nearSearch(final String word, final int distance)
+  public CharSequence[] nearSearch(final CharSequence word, final int distance)
   {
     if (comparator == CASE_INSENSITIVE_COMPARATOR) {
       throw new UnsupportedOperationException("Near search is not supported for case insensitive ternary trees");
     }
 
-    final List<String> matches = nearSearchNode(root, distance, null, "", word, 0);
-    return matches == null ? EMPTY_ARRAY : matches.toArray(new String[0]);
+    final List<CharSequence> matches = nearSearchNode(root, distance, null, "", word, 0);
+    return matches == null ? EMPTY_ARRAY : matches.toArray(new CharSequence[0]);
   }
 
 
@@ -160,9 +160,9 @@ public class TernaryTree
    *
    * @return  unmodifiable list of words
    */
-  public List<String> getWords()
+  public List<CharSequence> getWords()
   {
-    final List<String> words = traverseNode(root, "", new ArrayList<>());
+    final List<CharSequence> words = traverseNode(root, "", new ArrayList<>());
     return Collections.unmodifiableList(words);
   }
 
@@ -211,11 +211,12 @@ public class TernaryTree
    * @return  ternary node to insert
    */
   // CheckStyle:FinalParametersCheck OFF
-  private TernaryNode insertNode(TernaryNode node, final String word, final int index)
+  private TernaryNode insertNode(TernaryNode node, final CharSequence word, final int index)
   // CheckStyle:FinalParametersCheck ON
   {
     if (index < word.length()) {
-      final int cp = word.codePointAt(index);
+      final int[] codePoints = word.codePoints().toArray();
+      final int cp = codePoints[index];
       if (node == null) {
         // CheckStyle:ParameterAssignmentCheck OFF
         node = new TernaryNode(cp);
@@ -245,20 +246,20 @@ public class TernaryTree
    * @param  word  to search for
    * @param  index  of character in word
    *
-   * @return  whether or not the word was found
+   * @return  whether the word was found
    */
   // CheckStyle:ReturnCount OFF
-  private boolean searchNode(final TernaryNode node, final String word, final int index)
+  private boolean searchNode(final TernaryNode node, final int[] word, final int index)
   {
-    if (node != null && index < word.length()) {
-      final int cp = word.codePointAt(index);
+    if (node != null && index < word.length) {
+      final int cp = word[index];
       final String split = UnicodeString.toString(node.getSplitChar());
       final int cmp = comparator.compare(UnicodeString.toString(cp), split);
       if (cmp < 0) {
         return searchNode(node.getLokid(), word, index);
       } else if (cmp > 0) {
         return searchNode(node.getHikid(), word, index);
-      } else if (index == word.length() - 1) {
+      } else if (index == word.length - 1) {
         return node.isEndOfWord();
       } else {
         return searchNode(node.getEqkid(), word, index + Character.charCount(cp));
@@ -281,12 +282,13 @@ public class TernaryTree
    * @return  list of matches
    */
   // CheckStyle:FinalParametersCheck OFF
-  private List<String> partialSearchNode(final TernaryNode node, List<String> matches,
-    final String match, final String word, final int index)
+  private List<CharSequence> partialSearchNode(final TernaryNode node, List<CharSequence> matches,
+    final CharSequence match, final CharSequence word, final int index)
   // CheckStyle:FinalParametersCheck ON
   {
+    final int[] codePoints = word.codePoints().toArray();
     if (node != null && index < word.length()) {
-      final int cp = word.codePointAt(index);
+      final int cp = codePoints[index];
       final String split = UnicodeString.toString(node.getSplitChar());
       final int cmp = comparator.compare(UnicodeString.toString(cp), split);
       if (cp == '.' || cmp < 0) {
@@ -333,13 +335,14 @@ public class TernaryTree
    * @return  list of matches
    */
   // CheckStyle:FinalParametersCheck OFF
-  private List<String> nearSearchNode(final TernaryNode node, final int distance, List<String> matches,
-    final String match, final String word, final int index)
+  private List<CharSequence> nearSearchNode(final TernaryNode node, final int distance, List<CharSequence> matches,
+    final CharSequence match, final CharSequence word, final int index)
   // CheckStyle:FinalParametersCheck ON
   {
     if (node != null && distance >= 0) {
 
-      final int cp = index < word.length() ? word.codePointAt(index) : Character.MAX_VALUE;
+      final int[] codePoints = word.codePoints().toArray();
+      final int cp = index < word.length() ? codePoints[index] : Character.MAX_VALUE;
       final String split = UnicodeString.toString(node.getSplitChar());
       final int cmp = comparator.compare(UnicodeString.toString(cp), split);
 
@@ -400,7 +403,7 @@ public class TernaryTree
    * @return  list of strings containing all words from the supplied node
    */
   // CheckStyle:FinalParametersCheck OFF
-  private List<String> traverseNode(final TernaryNode node, final String s, List<String> words)
+  private List<CharSequence> traverseNode(final TernaryNode node, final String s, List<CharSequence> words)
   // CheckStyle:FinalParametersCheck ON
   {
     if (node != null) {

--- a/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
+++ b/src/main/java/org/passay/dictionary/TernaryTreeDictionary.java
@@ -89,7 +89,7 @@ public class TernaryTreeDictionary implements Dictionary
 
 
   @Override
-  public boolean search(final String word)
+  public boolean search(final CharSequence word)
   {
     return tree.search(word);
   }
@@ -103,7 +103,7 @@ public class TernaryTreeDictionary implements Dictionary
    *
    * @return  array of matching words
    */
-  public String[] partialSearch(final String word)
+  public CharSequence[] partialSearch(final CharSequence word)
   {
     return tree.partialSearch(word);
   }
@@ -118,7 +118,7 @@ public class TernaryTreeDictionary implements Dictionary
    *
    * @return  array of matching words
    */
-  public String[] nearSearch(final String word, final int distance)
+  public CharSequence[] nearSearch(final CharSequence word, final int distance)
   {
     return tree.nearSearch(word, distance);
   }
@@ -207,14 +207,14 @@ public class TernaryTreeDictionary implements Dictionary
           System.out.printf("%s was not found in this dictionary%n", word);
         }
       } else if (partialSearch) {
-        final String[] matches = dict.partialSearch(word);
+        final CharSequence[] matches = dict.partialSearch(word);
         System.out.printf(
           "Found %s matches for %s in this dictionary : %s%n",
           matches.length,
           word,
           Arrays.asList(matches));
       } else if (nearSearch) {
-        final String[] matches = dict.nearSearch(word, distance);
+        final CharSequence[] matches = dict.nearSearch(word, distance);
         System.out.printf(
           "Found %s matches for %s in this dictionary at a distance of %s " +
             ": %s%n",

--- a/src/main/java/org/passay/dictionary/WordList.java
+++ b/src/main/java/org/passay/dictionary/WordList.java
@@ -19,7 +19,7 @@ public interface WordList
    *
    * @return  comparator for words in the list.
    */
-  Comparator<String> getComparator();
+  Comparator<CharSequence> getComparator();
 
 
   /**

--- a/src/main/java/org/passay/dictionary/WordListDictionary.java
+++ b/src/main/java/org/passay/dictionary/WordListDictionary.java
@@ -52,7 +52,7 @@ public class WordListDictionary implements Dictionary
 
 
   @Override
-  public boolean search(final String word)
+  public boolean search(final CharSequence word)
   {
     return WordLists.binarySearch(wordList, word) >= 0;
   }

--- a/src/main/java/org/passay/dictionary/WordLists.java
+++ b/src/main/java/org/passay/dictionary/WordLists.java
@@ -26,13 +26,33 @@ public final class WordLists
 {
 
   /** Case sensitive comparator. */
-  public static final Comparator<String> CASE_SENSITIVE_COMPARATOR = new Comparator<String>() {
+  // CheckStyle:AnonInnerLength OFF
+  // CheckStyle:ReturnCount OFF
+  public static final Comparator<CharSequence> CASE_SENSITIVE_COMPARATOR = new Comparator<CharSequence>() {
     @Override
-    public int compare(final String a, final String b)
+    @SuppressWarnings("unchecked")
+    public int compare(final CharSequence a, final CharSequence b)
     {
-      PassayUtils.assertNotNullArg(a, "Compare string cannot be null");
-      PassayUtils.assertNotNullArg(b, "Compare string cannot be null");
-      return a.compareTo(b);
+      if (PassayUtils.assertNotNullArg(a, "Compare argument cannot be null") ==
+          PassayUtils.assertNotNullArg(b, "Compare argument cannot be null")) {
+        return 0;
+      }
+      final int[] codePointsA = a.codePoints().toArray();
+      final int[] codePointsB = b.codePoints().toArray();
+      try {
+        final int len = Math.min(codePointsA.length, codePointsB.length);
+        for (int i = 0; i < len; i++) {
+          final int charA = codePointsA[i];
+          final int charB = codePointsB[i];
+          if (charA != charB) {
+            return charA - charB;
+          }
+        }
+        return codePointsA.length - codePointsB.length;
+      } finally {
+        PassayUtils.clear(codePointsA);
+        PassayUtils.clear(codePointsB);
+      }
     }
     @Override
     public String toString()
@@ -40,15 +60,37 @@ public final class WordLists
       return getClass().getName() + "-CASE_SENSITIVE@" + hashCode();
     }
   };
+  // CheckStyle:ReturnCount ON
+  // CheckStyle:AnonInnerLength ON
 
   /** Case insensitive comparator. */
-  public static final Comparator<String> CASE_INSENSITIVE_COMPARATOR = new Comparator<String>() {
+  // CheckStyle:AnonInnerLength OFF
+  // CheckStyle:ReturnCount OFF
+  public static final Comparator<CharSequence> CASE_INSENSITIVE_COMPARATOR = new Comparator<CharSequence>() {
     @Override
-    public int compare(final String a, final String b)
+    @SuppressWarnings("unchecked")
+    public int compare(final CharSequence a, final CharSequence b)
     {
-      PassayUtils.assertNotNullArg(a, "Compare string cannot be null");
-      PassayUtils.assertNotNullArg(b, "Compare string cannot be null");
-      return a.compareToIgnoreCase(b);
+      if (PassayUtils.assertNotNullArg(a, "Compare argument cannot be null") ==
+          PassayUtils.assertNotNullArg(b, "Compare argument cannot be null")) {
+        return 0;
+      }
+      final int[] codePointsA = a.codePoints().toArray();
+      final int[] codePointsB = b.codePoints().toArray();
+      try {
+        final int len = Math.min(codePointsA.length, codePointsB.length);
+        for (int i = 0; i < len; i++) {
+          final int charA = Character.toLowerCase(codePointsA[i]);
+          final int charB = Character.toLowerCase(codePointsB[i]);
+          if (charA != charB) {
+            return charA - charB;
+          }
+        }
+        return codePointsA.length - codePointsB.length;
+      } finally {
+        PassayUtils.clear(codePointsA);
+        PassayUtils.clear(codePointsB);
+      }
     }
     @Override
     public String toString()
@@ -56,6 +98,8 @@ public final class WordLists
       return getClass().getName() + "-CASE_INSENSITIVE@" + hashCode();
     }
   };
+  // CheckStyle:ReturnCount ON
+  // CheckStyle:AnonInnerLength ON
 
   /** Index returned when word not found by binary search. */
   public static final int NOT_FOUND = -1;
@@ -73,11 +117,11 @@ public final class WordLists
    *
    * @return  index of supplied word in list or a negative number if not found.
    */
-  public static int binarySearch(final WordList wordList, final String word)
+  public static int binarySearch(final WordList wordList, final CharSequence word)
   {
     PassayUtils.assertNotNullArg(wordList, "Word list cannot be null");
     PassayUtils.assertNotNullArg(word, "Word cannot be null");
-    final Comparator<String> comparator = wordList.getComparator();
+    final Comparator<CharSequence> comparator = wordList.getComparator();
     int low = 0;
     int high = wordList.size() - 1;
     int mid;

--- a/src/main/java/org/passay/dictionary/sort/ArraySorter.java
+++ b/src/main/java/org/passay/dictionary/sort/ArraySorter.java
@@ -29,5 +29,5 @@ public interface ArraySorter
    * @param  array  To sort
    * @param  c  Comparator to sort with
    */
-  void sort(String[] array, Comparator<String> c);
+  void sort(String[] array, Comparator<CharSequence> c);
 }

--- a/src/main/java/org/passay/dictionary/sort/ArraysSort.java
+++ b/src/main/java/org/passay/dictionary/sort/ArraysSort.java
@@ -27,7 +27,7 @@ public class ArraysSort implements ArraySorter
 
 
   @Override
-  public void sort(final String[] array, final Comparator<String> comparator)
+  public void sort(final String[] array, final Comparator<CharSequence> comparator)
   {
     Arrays.sort(
       PassayUtils.assertNotNullArgOr(

--- a/src/main/java/org/passay/dictionary/sort/BubbleSort.java
+++ b/src/main/java/org/passay/dictionary/sort/BubbleSort.java
@@ -13,7 +13,7 @@ public class BubbleSort implements ArraySorter
 {
 
   @Override
-  public void sort(final String[] array, final Comparator<String> comparator)
+  public void sort(final String[] array, final Comparator<CharSequence> comparator)
   {
     PassayUtils.assertNotNullArg(array, "Array cannot be null");
     PassayUtils.assertNotNullArg(comparator, "Comparator cannot be null");

--- a/src/main/java/org/passay/dictionary/sort/InsertionSort.java
+++ b/src/main/java/org/passay/dictionary/sort/InsertionSort.java
@@ -13,7 +13,7 @@ public class InsertionSort implements ArraySorter
 {
 
   @Override
-  public void sort(final String[] array, final Comparator<String> comparator)
+  public void sort(final String[] array, final Comparator<CharSequence> comparator)
   {
     PassayUtils.assertNotNullArg(array, "Array cannot be null");
     PassayUtils.assertNotNullArg(comparator, "Comparator cannot be null");

--- a/src/main/java/org/passay/dictionary/sort/QuickSort.java
+++ b/src/main/java/org/passay/dictionary/sort/QuickSort.java
@@ -13,7 +13,7 @@ public class QuickSort implements ArraySorter
 {
 
   @Override
-  public void sort(final String[] array, final Comparator<String> comparator)
+  public void sort(final String[] array, final Comparator<CharSequence> comparator)
   {
     PassayUtils.assertNotNullArg(array, "Array cannot be null");
     PassayUtils.assertNotNullArg(comparator, "Comparator cannot be null");
@@ -32,7 +32,7 @@ public class QuickSort implements ArraySorter
    * @param  lo  index to beginning sorting at
    * @param  hi  index to stop sorting at
    */
-  public static void sort(final String[] array, final Comparator<String> c, final int lo, final int hi)
+  public static void sort(final String[] array, final Comparator<CharSequence> c, final int lo, final int hi)
   {
     PassayUtils.assertNotNullArg(array, "Array cannot be null");
     PassayUtils.assertNotNullArg(c, "Comparator cannot be null");

--- a/src/main/java/org/passay/dictionary/sort/SelectionSort.java
+++ b/src/main/java/org/passay/dictionary/sort/SelectionSort.java
@@ -13,7 +13,7 @@ public class SelectionSort implements ArraySorter
 {
 
   @Override
-  public void sort(final String[] array, final Comparator<String> comparator)
+  public void sort(final String[] array, final Comparator<CharSequence> comparator)
   {
     PassayUtils.assertNotNullArg(array, "Array cannot be null");
     PassayUtils.assertNotNullArg(comparator, "Comparator cannot be null");

--- a/src/main/java/org/passay/entropy/RandomPasswordEntropyFactory.java
+++ b/src/main/java/org/passay/entropy/RandomPasswordEntropyFactory.java
@@ -55,7 +55,7 @@ public final class RandomPasswordEntropyFactory
       } else if (rule instanceof AllowedCharacterRule) {
         final AllowedCharacterRule allowedCharacterRule = (AllowedCharacterRule) rule;
         uniqueCharacters.addAll(
-          getUniqueCharacters(UnicodeString.toString(allowedCharacterRule.getAllowedCharacters().getCodePoints())));
+          getUniqueCharacters(UnicodeString.toString(allowedCharacterRule.getAllowedCharacters())));
       }
     });
     if (uniqueCharacters.isEmpty()) {

--- a/src/main/java/org/passay/rule/AbstractDictionaryRule.java
+++ b/src/main/java/org/passay/rule/AbstractDictionaryRule.java
@@ -11,6 +11,7 @@ import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 import org.passay.dictionary.Dictionary;
 
 /**
@@ -69,19 +70,23 @@ public abstract class AbstractDictionaryRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    String text = passwordData.getPassword();
-    String matchingWord = doWordSearch(text);
-    if (matchingWord != null) {
-      details.add(new RuleResultDetail(getErrorCode(false), createRuleResultDetailParameters(matchingWord)));
-    }
-    if (matchBackwards && text.length() > 1) {
-      text = new StringBuilder(passwordData.getPassword()).reverse().toString();
-      matchingWord = doWordSearch(text);
+    UnicodeString text = UnicodeString.copy(passwordData.getPassword());
+    try {
+      CharSequence matchingWord = doWordSearch(text);
       if (matchingWord != null) {
-        details.add(new RuleResultDetail(getErrorCode(true), createRuleResultDetailParameters(matchingWord)));
+        details.add(new RuleResultDetail(getErrorCode(false), createRuleResultDetailParameters(matchingWord)));
       }
+      if (matchBackwards && text.length() > 1) {
+        text = text.reverse(true);
+        matchingWord = doWordSearch(text);
+        if (matchingWord != null) {
+          details.add(new RuleResultDetail(getErrorCode(true), createRuleResultDetailParameters(matchingWord)));
+        }
+      }
+      return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
+    } finally {
+      text.clear();
     }
-    return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
   }
 
 
@@ -92,7 +97,7 @@ public abstract class AbstractDictionaryRule implements Rule
    *
    * @return  map of parameter name to value
    */
-  protected Map<String, Object> createRuleResultDetailParameters(final String word)
+  protected Map<String, Object> createRuleResultDetailParameters(final CharSequence word)
   {
     final Map<String, Object> m = new LinkedHashMap<>();
     m.put("matchingWord", word);
@@ -117,7 +122,7 @@ public abstract class AbstractDictionaryRule implements Rule
    *
    * @return  matching word
    */
-  protected abstract String doWordSearch(String text);
+  protected abstract CharSequence doWordSearch(UnicodeString text);
 
 
   @Override

--- a/src/main/java/org/passay/rule/AllowedCharacterRule.java
+++ b/src/main/java/org/passay/rule/AllowedCharacterRule.java
@@ -83,7 +83,7 @@ public class AllowedCharacterRule implements Rule
    */
   public AllowedCharacterRule(final UnicodeString unicodeString, final MatchBehavior behavior, final boolean reportAll)
   {
-    allowedCharacters = unicodeString.getCodePoints();
+    allowedCharacters = unicodeString.codePoints();
     Arrays.sort(allowedCharacters);
     matchBehavior = behavior;
     reportAllFailures = reportAll;
@@ -118,26 +118,31 @@ public class AllowedCharacterRule implements Rule
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
     final Set<String> matches = new HashSet<>();
-    final String text = passwordData.getPassword();
-    for (int cp : text.codePoints().toArray()) {
-      if (Arrays.binarySearch(allowedCharacters, cp) < 0 && !matches.contains(UnicodeString.toString(cp))) {
-        if (MatchBehavior.Contains.equals(matchBehavior) || matchBehavior.match(text, cp)) {
-          final String[] codes = {
-            ERROR_CODE + "." + cp,
-            ERROR_CODE + "." + matchBehavior.upperSnakeName(),
-            ERROR_CODE,
-          };
-          details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(cp)));
-          if (!reportAllFailures) {
-            break;
+    final UnicodeString text = passwordData.getPassword();
+    final int[] codePoints = text.codePoints();
+    try {
+      for (int cp : codePoints) {
+        if (Arrays.binarySearch(allowedCharacters, cp) < 0 && !matches.contains(UnicodeString.toString(cp))) {
+          if (MatchBehavior.Contains.equals(matchBehavior) || matchBehavior.match(text, cp)) {
+            final String[] codes = {
+              ERROR_CODE + "." + cp,
+              ERROR_CODE + "." + matchBehavior.upperSnakeName(),
+              ERROR_CODE,
+            };
+            details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(cp)));
+            if (!reportAllFailures) {
+              break;
+            }
+            matches.add(UnicodeString.toString(cp));
           }
-          matches.add(UnicodeString.toString(cp));
         }
       }
+      return details.isEmpty() ?
+        new SuccessRuleResult(createRuleResultMetadata(passwordData)) :
+        new FailureRuleResult(createRuleResultMetadata(passwordData), details);
+    } finally {
+      PassayUtils.clear(codePoints);
     }
-    return details.isEmpty() ?
-      new SuccessRuleResult(createRuleResultMetadata(passwordData)) :
-      new FailureRuleResult(createRuleResultMetadata(passwordData), details);
   }
 
 
@@ -168,7 +173,7 @@ public class AllowedCharacterRule implements Rule
   {
     return new RuleResultMetadata(
       RuleResultMetadata.CountCategory.Allowed,
-      UnicodeString.countMatchingCharacters(allowedCharacters, password.getPassword()));
+      password.getPassword().countMatchingCharacters(allowedCharacters));
   }
 
 

--- a/src/main/java/org/passay/rule/AllowedRegexRule.java
+++ b/src/main/java/org/passay/rule/AllowedRegexRule.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -66,11 +67,16 @@ public class AllowedRegexRule implements Rule
   public RuleResult validate(final PasswordData passwordData)
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
-    final Matcher m = pattern.matcher(passwordData.getPassword());
-    if (!m.find()) {
-      return new FailureRuleResult(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters()));
+    final CharBuffer password = passwordData.getPassword().toCharBuffer();
+    try {
+      final Matcher m = pattern.matcher(password);
+      if (!m.find()) {
+        return new FailureRuleResult(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters()));
+      }
+      return new SuccessRuleResult();
+    } finally {
+      PassayUtils.clear(password);
     }
-    return new SuccessRuleResult();
   }
 
 

--- a/src/main/java/org/passay/rule/CharacterOccurrencesRule.java
+++ b/src/main/java/org/passay/rule/CharacterOccurrencesRule.java
@@ -44,24 +44,29 @@ public class CharacterOccurrencesRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String password = passwordData.getPassword();
-    final int[] codePoints = IntStream.concat(password.codePoints(), IntStream.of(Integer.MAX_VALUE)).toArray();
+    final UnicodeString password = passwordData.getPassword();
+    final int[] codePoints = IntStream.concat(
+      IntStream.of(password.codePoints()), IntStream.of(Integer.MAX_VALUE)).toArray();
     Arrays.sort(codePoints);
-    int repeat = 1;
-    for (int i = 1; i < codePoints.length; i++) {
-      if (codePoints[i] == codePoints[i - 1]) {
-        repeat++;
-      } else {
-        if (repeat > maxOccurrences) {
-          details.add(
-            new RuleResultDetail(
+    try {
+      int repeat = 1;
+      for (int i = 1; i < codePoints.length; i++) {
+        if (codePoints[i] == codePoints[i - 1]) {
+          repeat++;
+        } else {
+          if (repeat > maxOccurrences) {
+            details.add(
+              new RuleResultDetail(
                 ERROR_CODE,
                 createRuleResultDetailParameters(UnicodeString.toString(codePoints[i - 1]), repeat)));
+          }
+          repeat = 1;
         }
-        repeat = 1;
       }
+      return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
+    } finally {
+      PassayUtils.clear(codePoints);
     }
-    return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
   }
 
   /**

--- a/src/main/java/org/passay/rule/CharacterRule.java
+++ b/src/main/java/org/passay/rule/CharacterRule.java
@@ -93,7 +93,7 @@ public class CharacterRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final String matchingChars = getMatchingCharacters(
-      String.valueOf(characterData.getCharacters()),
+      characterData.getCharacters(),
       passwordData.getPassword(),
       numCharacters);
     if (matchingChars.length() < numCharacters) {
@@ -135,7 +135,7 @@ public class CharacterRule implements Rule
     try {
       return new RuleResultMetadata(
         RuleResultMetadata.CountCategory.valueOf(characterData.toString()),
-        UnicodeString.countMatchingCharacters(characterData.getCharacters(), password.getPassword()));
+        password.getPassword().countMatchingCharacters(characterData.getCharacters().codePoints().toArray()));
     } catch (IllegalArgumentException e) {
       return new RuleResultMetadata();
     }
@@ -151,7 +151,8 @@ public class CharacterRule implements Rule
    *
    * @return  matching characters or empty string
    */
-  private static String getMatchingCharacters(final String characters, final String input, final int maximumLength)
+  private static String getMatchingCharacters(
+    final String characters, final UnicodeString input, final int maximumLength)
   {
     final StringBuilder sb = new StringBuilder(input.length());
     int i = 0;
@@ -164,7 +165,7 @@ public class CharacterRule implements Rule
           break;
         }
       }
-      i += Character.charCount(cp);
+      i++;
     }
     return sb.toString();
   }

--- a/src/main/java/org/passay/rule/DictionaryRule.java
+++ b/src/main/java/org/passay/rule/DictionaryRule.java
@@ -1,6 +1,9 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
+import org.passay.PassayUtils;
+import org.passay.UnicodeString;
 import org.passay.dictionary.Dictionary;
 
 /**
@@ -43,9 +46,14 @@ public class DictionaryRule extends AbstractDictionaryRule
 
 
   @Override
-  protected String doWordSearch(final String text)
+  protected CharSequence doWordSearch(final UnicodeString text)
   {
-    return getDictionary().search(text) ? text : null;
+    final CharBuffer buffer = text.toCharBuffer();
+    if (getDictionary().search(buffer)) {
+      return buffer;
+    }
+    PassayUtils.clear(buffer);
+    return null;
   }
 
 

--- a/src/main/java/org/passay/rule/DictionarySubstringRule.java
+++ b/src/main/java/org/passay/rule/DictionarySubstringRule.java
@@ -1,6 +1,9 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
+import org.passay.PassayUtils;
+import org.passay.UnicodeString;
 import org.passay.dictionary.Dictionary;
 
 /**
@@ -42,19 +45,20 @@ public class DictionarySubstringRule extends AbstractDictionaryRule
 
 
   @Override
-  protected String doWordSearch(final String text)
+  protected CharSequence doWordSearch(final UnicodeString text)
   {
-    int i = Character.charCount(text.codePointAt(0));
+    int i = 1;
     while (i < text.length()) {
       int j = 0;
       while (j + i <= text.length()) {
-        final String s = text.substring(j, j + i);
-        if (getDictionary().search(s)) {
-          return s;
+        final CharBuffer cb = text.substring(j, j + i).toCharBuffer(true);
+        if (getDictionary().search(cb)) {
+          return cb;
         }
-        j += Character.charCount(text.codePointAt(j));
+        PassayUtils.clear(cb);
+        j++;
       }
-      i += Character.charCount(text.codePointAt(i));
+      i++;
     }
     return null;
   }

--- a/src/main/java/org/passay/rule/DigestDictionaryRule.java
+++ b/src/main/java/org/passay/rule/DigestDictionaryRule.java
@@ -1,10 +1,13 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.Buffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cryptacular.bean.HashBean;
 import org.passay.PassayUtils;
+import org.passay.UnicodeString;
 import org.passay.dictionary.Dictionary;
 
 /**
@@ -74,9 +77,20 @@ public class DigestDictionaryRule extends AbstractDictionaryRule
 
 
   @Override
-  protected String doWordSearch(final String text)
+  protected CharSequence doWordSearch(final UnicodeString text)
   {
-    return getDictionary().search(hashBean.hash(text.getBytes(charset))) ? text : null;
+    final CharBuffer buffer = text.toCharBuffer();
+    try {
+      final byte[] bytes = PassayUtils.toByteArray(buffer, charset);
+      try {
+        ((Buffer) buffer).rewind();
+        return getDictionary().search(hashBean.hash(bytes)) ? buffer : null;
+      } finally {
+        PassayUtils.clear(bytes);
+      }
+    } finally {
+      PassayUtils.clear(buffer);
+    }
   }
 
 

--- a/src/main/java/org/passay/rule/DigestHistoryRule.java
+++ b/src/main/java/org/passay/rule/DigestHistoryRule.java
@@ -1,11 +1,13 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cryptacular.bean.HashBean;
 import org.passay.PassayUtils;
 import org.passay.PasswordData;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password matches one of any previous digested password a user has chosen. If no password
@@ -57,10 +59,17 @@ public class DigestHistoryRule extends HistoryRule
    * @return  true if passwords match, false otherwise.
    */
   @Override
-  protected boolean matches(final String password, final PasswordData.Reference reference)
+  protected boolean matches(final UnicodeString password, final PasswordData.Reference reference)
   {
     final PasswordData.Salt salt = reference.getSalt();
-    final String undigested = salt == null ? password : salt.applyTo(password);
-    return hashBean.compare(reference.getPassword(), undigested.getBytes(charset));
+    final CharBuffer buffer = password.toCharBuffer();
+    final CharBuffer undigested = salt == null ? buffer : salt.applyTo(buffer);
+    try {
+      return hashBean.compare(
+        UnicodeString.toString(reference.getPassword()), PassayUtils.toByteArray(undigested, charset));
+    } finally {
+      PassayUtils.clear(buffer);
+      PassayUtils.clear(undigested);
+    }
   }
 }

--- a/src/main/java/org/passay/rule/DigestSourceRule.java
+++ b/src/main/java/org/passay/rule/DigestSourceRule.java
@@ -1,11 +1,13 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cryptacular.bean.HashBean;
 import org.passay.PassayUtils;
 import org.passay.PasswordData;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password matches a digested password from a different source. Useful for when separate
@@ -57,10 +59,17 @@ public class DigestSourceRule extends SourceRule
    * @return  true if passwords match, false otherwise.
    */
   @Override
-  protected boolean matches(final String password, final PasswordData.Reference reference)
+  protected boolean matches(final UnicodeString password, final PasswordData.Reference reference)
   {
     final PasswordData.Salt salt = reference.getSalt();
-    final String undigested = salt == null ? password : salt.applyTo(password);
-    return hashBean.compare(reference.getPassword(), undigested.getBytes(charset));
+    final CharBuffer buffer = password.toCharBuffer();
+    final CharBuffer undigested = salt == null ? buffer : salt.applyTo(buffer);
+    try {
+      return hashBean.compare(
+        UnicodeString.toString(reference.getPassword()), PassayUtils.toByteArray(undigested, charset));
+    } finally {
+      PassayUtils.clear(buffer);
+      PassayUtils.clear(undigested);
+    }
   }
 }

--- a/src/main/java/org/passay/rule/HaveIBeenPwnedRule.java
+++ b/src/main/java/org/passay/rule/HaveIBeenPwnedRule.java
@@ -7,6 +7,7 @@ import java.io.LineNumberReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -212,8 +213,18 @@ public class HaveIBeenPwnedRule implements Rule
    */
   private static String getHexDigest(final PasswordData passwordData)
   {
-    final byte[] digest = HashUtil.sha1(passwordData.getPassword().getBytes(Charset.defaultCharset()));
-    return CodecUtil.encode(new HexEncoder(false, true), digest);
+    final CharBuffer buffer = passwordData.getPassword().toCharBuffer();
+    try {
+      final byte[] bytes = PassayUtils.toByteArray(buffer, Charset.defaultCharset());
+      try {
+        final byte[] digest = HashUtil.sha1(bytes);
+        return CodecUtil.encode(new HexEncoder(false, true), digest);
+      } finally {
+        PassayUtils.clear(bytes);
+      }
+    } finally {
+      PassayUtils.clear(buffer);
+    }
   }
 
 

--- a/src/main/java/org/passay/rule/HistoryRule.java
+++ b/src/main/java/org/passay/rule/HistoryRule.java
@@ -11,6 +11,7 @@ import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password matches one of any previous password a user has chosen. If no historical password
@@ -60,7 +61,7 @@ public class HistoryRule implements Rule
     }
 
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String cleartext = passwordData.getPassword();
+    final UnicodeString cleartext = passwordData.getPassword();
     if (reportAllFailures) {
       references.stream()
         .filter(r -> matches(cleartext, r))
@@ -83,7 +84,7 @@ public class HistoryRule implements Rule
    *
    * @return  true if passwords match, false otherwise.
    */
-  protected boolean matches(final String password, final PasswordData.Reference reference)
+  protected boolean matches(final UnicodeString password, final PasswordData.Reference reference)
   {
     return password.equals(reference.getPassword());
   }

--- a/src/main/java/org/passay/rule/IllegalCharacterRule.java
+++ b/src/main/java/org/passay/rule/IllegalCharacterRule.java
@@ -83,7 +83,7 @@ public class IllegalCharacterRule implements Rule
    */
   public IllegalCharacterRule(final UnicodeString unicodeString, final MatchBehavior behavior, final boolean reportAll)
   {
-    illegalCharacters = unicodeString.getCodePoints();
+    illegalCharacters = unicodeString.codePoints();
     matchBehavior = behavior;
     reportAllFailures = reportAll;
   }
@@ -117,7 +117,7 @@ public class IllegalCharacterRule implements Rule
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
     final Set<String> matches = new HashSet<>();
-    final String text = passwordData.getPassword();
+    final UnicodeString text = passwordData.getPassword();
     for (int cp : illegalCharacters) {
       if (matchBehavior.match(text, cp) && !matches.contains(UnicodeString.toString(cp))) {
         final String[] codes = {
@@ -165,7 +165,7 @@ public class IllegalCharacterRule implements Rule
   {
     return new RuleResultMetadata(
       RuleResultMetadata.CountCategory.Illegal,
-      UnicodeString.countMatchingCharacters(illegalCharacters, password.getPassword()));
+      password.getPassword().countMatchingCharacters(illegalCharacters));
   }
 
 

--- a/src/main/java/org/passay/rule/IllegalRegexRule.java
+++ b/src/main/java/org/passay/rule/IllegalRegexRule.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -100,20 +101,25 @@ public class IllegalRegexRule implements Rule
   public RuleResult validate(final PasswordData passwordData)
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
-    final List<RuleResultDetail> details = new ArrayList<>();
-    final Matcher m = pattern.matcher(passwordData.getPassword());
-    final Set<String> matches = new HashSet<>();
-    while (m.find()) {
-      final String match = m.group();
-      if (!matches.contains(match)) {
-        details.add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(match)));
-        if (!reportAllFailures) {
-          break;
+    final CharBuffer password = passwordData.getPassword().toCharBuffer();
+    try {
+      final List<RuleResultDetail> details = new ArrayList<>();
+      final Matcher m = pattern.matcher(password);
+      final Set<String> matches = new HashSet<>();
+      while (m.find()) {
+        final String match = m.group();
+        if (!matches.contains(match)) {
+          details.add(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(match)));
+          if (!reportAllFailures) {
+            break;
+          }
+          matches.add(match);
         }
-        matches.add(match);
       }
+      return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
+    } finally {
+      PassayUtils.clear(password);
     }
-    return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
   }
 
 

--- a/src/main/java/org/passay/rule/IllegalSequenceRule.java
+++ b/src/main/java/org/passay/rule/IllegalSequenceRule.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 import org.passay.FailureRuleResult;
 import org.passay.PassayUtils;
 import org.passay.PasswordData;
@@ -114,41 +115,48 @@ public class IllegalSequenceRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String password = passwordData.getPassword() + '\uffff';
-    final StringBuilder match = new StringBuilder(password.length());
-    for (CharacterSequence cs : sequenceData.getSequences()) {
-      final int csLength = cs.length();
-      int direction = 0;
-      int prevPosition = -1;
-      int i = 0;
-      while (i < password.length()) {
-        final int cp = password.codePointAt(i);
-        final int position = indexOf(cs, cp);
-        // set diff to +1 for increase in sequence, -1 for decrease, anything else for neither
-        int diff = (position | prevPosition) < 0 ? 0 : position - prevPosition;
-        if (wrapSequence && (diff == csLength - 1 || diff == 1 - csLength)) {
-          diff -= Integer.signum(diff) * csLength;
-        }
-        // if we have a sequence and reached its end, add it to result
-        if (diff != direction && match.length() >= sequenceLength) {
-          addError(details, match.toString());
-        }
-        // update the current potential sequence
-        if (diff == 1 || diff == -1) {
-          if (diff != direction) {
-            match.delete(0, match.length() - 1);
-            direction = diff;
+    final int[] codePoints = IntStream.concat(
+      IntStream.of(passwordData.getPassword().codePoints()), IntStream.of('\uffff')).toArray();
+    final UnicodeString password = new UnicodeString(codePoints);
+    try {
+      final StringBuilder match = new StringBuilder(password.length());
+      for (CharacterSequence cs : sequenceData.getSequences()) {
+        final int csLength = cs.length();
+        int direction = 0;
+        int prevPosition = -1;
+        int i = 0;
+        while (i < password.length()) {
+          final int cp = password.codePointAt(i);
+          final int position = indexOf(cs, cp);
+          // set diff to +1 for increase in sequence, -1 for decrease, anything else for neither
+          int diff = (position | prevPosition) < 0 ? 0 : position - prevPosition;
+          if (wrapSequence && (diff == csLength - 1 || diff == 1 - csLength)) {
+            diff -= Integer.signum(diff) * csLength;
           }
-        } else {
-          match.setLength(0);
-          direction = 0;
+          // if we have a sequence and reached its end, add it to result
+          if (diff != direction && match.length() >= sequenceLength) {
+            addError(details, match.toString());
+          }
+          // update the current potential sequence
+          if (diff == 1 || diff == -1) {
+            if (diff != direction) {
+              match.delete(0, match.length() - 1);
+              direction = diff;
+            }
+          } else {
+            match.setLength(0);
+            direction = 0;
+          }
+          match.append(UnicodeString.toString(cp));
+          prevPosition = position;
+          i++;
         }
-        match.append(UnicodeString.toString(cp));
-        prevPosition = position;
-        i += Character.charCount(cp);
       }
+      return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
+    } finally {
+      PassayUtils.clear(codePoints);
+      password.clear();
     }
-    return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
   }
 
 

--- a/src/main/java/org/passay/rule/MatchBehavior.java
+++ b/src/main/java/org/passay/rule/MatchBehavior.java
@@ -12,20 +12,20 @@ import org.passay.UnicodeString;
 public enum MatchBehavior
 {
 
-  /** Use {@link String#startsWith(String)}. */
-  StartsWith("starts with", String::startsWith),
+  /** Use {@link UnicodeString#startsWith(UnicodeString)}. */
+  StartsWith("starts with", UnicodeString::startsWith),
 
-  /** Use {@link String#endsWith(String)}. */
-  EndsWith("ends with", String::endsWith),
+  /** Use {@link UnicodeString#endsWith(UnicodeString)}. */
+  EndsWith("ends with", UnicodeString::endsWith),
 
-  /** Use {@link String#contains(CharSequence)}. */
-  Contains("contains", String::contains);
+  /** Use {@link UnicodeString#contains(UnicodeString)}. */
+  Contains("contains", UnicodeString::contains);
 
   /** The description of the match behavior. **/
   private final String description;
 
   /** The matcher function. **/
-  private final BiFunction<String, String, Boolean> matcher;
+  private final BiFunction<UnicodeString, UnicodeString, Boolean> matcher;
 
   /**
    * Constructs a MatchBehavior constant.
@@ -33,7 +33,7 @@ public enum MatchBehavior
    * @param desc the behavior description
    * @param matcherFunction the matcher function
    */
-  MatchBehavior(final String desc, final BiFunction<String, String, Boolean> matcherFunction)
+  MatchBehavior(final String desc, final BiFunction<UnicodeString, UnicodeString, Boolean> matcherFunction)
   {
     description = desc;
     matcher = matcherFunction;
@@ -72,7 +72,7 @@ public enum MatchBehavior
    *
    * @return  whether text matches the supplied string for this match type
    */
-  public boolean match(final String text, final int cp)
+  public boolean match(final UnicodeString text, final int cp)
   {
     return match(text, UnicodeString.toString(cp));
   }
@@ -86,7 +86,21 @@ public enum MatchBehavior
    *
    * @return  whether text matches the supplied string for this match type
    */
-  public boolean match(final String text, final String s)
+  public boolean match(final UnicodeString text, final CharSequence s)
+  {
+    return match(text, new UnicodeString(s));
+  }
+
+
+  /**
+   * Returns whether text matches the supplied string for this match type.
+   *
+   * @param  text  to search
+   * @param  s  to find in text
+   *
+   * @return  whether text matches the supplied string for this match type
+   */
+  public boolean match(final UnicodeString text, final UnicodeString s)
   {
     return matcher.apply(text, s);
   }

--- a/src/main/java/org/passay/rule/NumberRangeRule.java
+++ b/src/main/java/org/passay/rule/NumberRangeRule.java
@@ -11,6 +11,7 @@ import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password contains any number within a defined range, lower inclusive, upper exclusive.
@@ -132,7 +133,7 @@ public class NumberRangeRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String text = passwordData.getPassword();
+    final UnicodeString text = passwordData.getPassword();
     for (int i = lowerRange; i < upperRange; i++) {
       if (matchBehavior.match(text, Integer.toString(i))) {
         final String[] codes = {

--- a/src/main/java/org/passay/rule/RepeatCharactersRule.java
+++ b/src/main/java/org/passay/rule/RepeatCharactersRule.java
@@ -5,12 +5,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 import org.passay.FailureRuleResult;
 import org.passay.PassayUtils;
 import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password contains multiple sequences of repeating characters.
@@ -81,32 +83,39 @@ public class RepeatCharactersRule implements Rule
   public RuleResult validate(final PasswordData passwordData)
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
-    final List<String> matches = new ArrayList<>();
-    final String password = passwordData.getPassword() + '\uffff';
-    final int max = password.length() - 1;
-    int count = 0;
-    int repeat = 1;
-    int prev = -1;
-    int i = 0;
-    while (i <= max) {
-      final int curr = password.codePointAt(i);
-      if (curr == prev) {
-        repeat++;
-      } else {
-        if (repeat >= sequenceLength) {
-          final String match = password.substring(i - Character.charCount(prev) * repeat, i);
-          matches.add(match);
-          count++;
+    final List<CharSequence> matches = new ArrayList<>();
+    final int[] codePoints = IntStream.concat(
+      IntStream.of(passwordData.getPassword().codePoints()), IntStream.of('\uffff')).toArray();
+    final UnicodeString password = new UnicodeString(codePoints);
+    PassayUtils.clear(codePoints);
+    try {
+      final int max = password.length() - 1;
+      int count = 0;
+      int repeat = 1;
+      int prev = -1;
+      int i = 0;
+      while (i <= max) {
+        final int curr = password.codePointAt(i);
+        if (curr == prev) {
+          repeat++;
+        } else {
+          if (repeat >= sequenceLength) {
+            final CharSequence match = password.substring(i - repeat, i).toCharBuffer(true);
+            matches.add(match);
+            count++;
+          }
+          repeat = 1;
         }
-        repeat = 1;
+        prev = curr;
+        i++;
       }
-      prev = curr;
-      i += Character.charCount(curr);
+      if (count >= sequenceCount) {
+        return new FailureRuleResult(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(matches)));
+      }
+      return new SuccessRuleResult();
+    } finally {
+      password.clear();
     }
-    if (count >= sequenceCount) {
-      return new FailureRuleResult(new RuleResultDetail(ERROR_CODE, createRuleResultDetailParameters(matches)));
-    }
-    return new SuccessRuleResult();
   }
 
   /**
@@ -116,7 +125,7 @@ public class RepeatCharactersRule implements Rule
    *
    * @return  map of parameter name to value
    */
-  protected Map<String, Object> createRuleResultDetailParameters(final List<String> matches)
+  protected Map<String, Object> createRuleResultDetailParameters(final List<CharSequence> matches)
   {
     final Map<String, Object> m = new LinkedHashMap<>();
     m.put("sequenceLength", sequenceLength);

--- a/src/main/java/org/passay/rule/SourceRule.java
+++ b/src/main/java/org/passay/rule/SourceRule.java
@@ -11,6 +11,7 @@ import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password matches a password from a different source. Useful for when separate systems
@@ -60,7 +61,7 @@ public class SourceRule implements Rule
     }
 
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String cleartext = passwordData.getPassword();
+    final UnicodeString cleartext = passwordData.getPassword();
     if (reportAllFailures) {
       references.stream()
         .filter(r -> matches(cleartext, r))
@@ -83,7 +84,7 @@ public class SourceRule implements Rule
    *
    * @return  true if passwords match, false otherwise.
    */
-  protected boolean matches(final String password, final PasswordData.Reference reference)
+  protected boolean matches(final UnicodeString password, final PasswordData.Reference reference)
   {
     return password.equals(reference.getPassword());
   }

--- a/src/main/java/org/passay/rule/UsernameRule.java
+++ b/src/main/java/org/passay/rule/UsernameRule.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.passay.rule;
 
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -11,6 +12,7 @@ import org.passay.PasswordData;
 import org.passay.RuleResult;
 import org.passay.RuleResultDetail;
 import org.passay.SuccessRuleResult;
+import org.passay.UnicodeString;
 
 /**
  * Rule for determining if a password contains the username associated with that password.  This rule returns true if a
@@ -109,29 +111,34 @@ public class UsernameRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    String user = passwordData.getUsername();
-    if (user != null && !user.isEmpty()) {
-      String text = passwordData.getPassword();
-      if (ignoreCase) {
-        text = text.toLowerCase();
-        user = user.toLowerCase();
-      }
-      if (matchBehavior.match(text, user)) {
-        final String[] codes = {
-          ERROR_CODE + "." + matchBehavior.upperSnakeName(),
-          ERROR_CODE,
-        };
-        details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(user)));
-      }
-      if (matchBackwards) {
-        final String reverseUser = new StringBuilder(user).reverse().toString();
-        if (matchBehavior.match(text, reverseUser)) {
-          final String[] codes = {
-            ERROR_CODE_REVERSED + "." + matchBehavior.upperSnakeName(),
-            ERROR_CODE_REVERSED,
-          };
-          details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(user)));
+    if (passwordData.getUsername() != null && !passwordData.getUsername().isEmpty()) {
+      UnicodeString text = UnicodeString.copy(passwordData.getPassword());
+      UnicodeString user = UnicodeString.copy(passwordData.getUsername());
+      try {
+        if (ignoreCase) {
+          text = text.toLowerCase(true);
+          user = user.toLowerCase(true);
         }
+        if (matchBehavior.match(text, user)) {
+          final String[] codes = {
+            ERROR_CODE + "." + matchBehavior.upperSnakeName(),
+            ERROR_CODE,
+          };
+          details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(UnicodeString.toString(user))));
+        }
+        if (matchBackwards) {
+          final CharBuffer reverseUser = user.reverse().toCharBuffer(true);
+          if (matchBehavior.match(text, reverseUser)) {
+            final String[] codes = {
+              ERROR_CODE_REVERSED + "." + matchBehavior.upperSnakeName(),
+              ERROR_CODE_REVERSED,
+            };
+            details.add(new RuleResultDetail(codes, createRuleResultDetailParameters(UnicodeString.toString(user))));
+          }
+        }
+      } finally {
+        text.clear();
+        user.clear();
       }
     }
     return details.isEmpty() ? new SuccessRuleResult() : new FailureRuleResult(details);
@@ -145,7 +152,7 @@ public class UsernameRule implements Rule
    *
    * @return  map of parameter name to value
    */
-  protected Map<String, Object> createRuleResultDetailParameters(final String username)
+  protected Map<String, Object> createRuleResultDetailParameters(final CharSequence username)
   {
     final Map<String, Object> m = new LinkedHashMap<>();
     m.put("username", username);

--- a/src/main/java/org/passay/rule/WhitespaceRule.java
+++ b/src/main/java/org/passay/rule/WhitespaceRule.java
@@ -117,7 +117,7 @@ public class WhitespaceRule implements Rule
    */
   public WhitespaceRule(final UnicodeString unicodeString, final MatchBehavior behavior, final boolean reportAll)
   {
-    final int[] cp = unicodeString.getCodePoints();
+    final int[] cp = unicodeString.codePoints();
     for (int c : cp) {
       if (!Character.isWhitespace(c)) {
         throw new IllegalArgumentException("Character '" + c + "' is not whitespace");
@@ -156,7 +156,7 @@ public class WhitespaceRule implements Rule
   {
     PassayUtils.assertNotNullArg(passwordData, "Password data cannot be null");
     final List<RuleResultDetail> details = new ArrayList<>();
-    final String text = passwordData.getPassword();
+    final UnicodeString text = passwordData.getPassword();
     for (int cp : whitespaceCharacters) {
       if (matchBehavior.match(text, cp)) {
         final String[] codes = {
@@ -202,7 +202,7 @@ public class WhitespaceRule implements Rule
   {
     return new RuleResultMetadata(
       RuleResultMetadata.CountCategory.Whitespace,
-      UnicodeString.countMatchingCharacters(whitespaceCharacters, password.getPassword()));
+      password.getPassword().countMatchingCharacters(whitespaceCharacters));
   }
 
 

--- a/src/test/java/org/passay/HeapDump.java
+++ b/src/test/java/org/passay/HeapDump.java
@@ -1,0 +1,237 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+import java.io.FileReader;
+import java.lang.management.ManagementFactory;
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import javax.management.MBeanServer;
+import com.sun.management.HotSpotDiagnosticMXBean;
+import org.cryptacular.bean.EncodingHashBean;
+import org.cryptacular.spec.CodecSpec;
+import org.cryptacular.spec.DigestSpec;
+import org.passay.data.EnglishCharacterData;
+import org.passay.data.EnglishSequenceData;
+import org.passay.dictionary.ArrayWordList;
+import org.passay.dictionary.Dictionary;
+import org.passay.dictionary.WordListDictionary;
+import org.passay.dictionary.WordLists;
+import org.passay.dictionary.sort.ArraysSort;
+import org.passay.rule.AllowedCharacterRule;
+import org.passay.rule.AllowedRegexRule;
+import org.passay.rule.CharacterCharacteristicsRule;
+import org.passay.rule.CharacterOccurrencesRule;
+import org.passay.rule.CharacterRule;
+import org.passay.rule.DictionarySubstringRule;
+import org.passay.rule.DigestHistoryRule;
+import org.passay.rule.DigestSourceRule;
+import org.passay.rule.IllegalCharacterRule;
+import org.passay.rule.IllegalRegexRule;
+import org.passay.rule.IllegalSequenceRule;
+import org.passay.rule.LengthComplexityRule;
+import org.passay.rule.LengthRule;
+import org.passay.rule.NumberRangeRule;
+import org.passay.rule.RepeatCharacterRegexRule;
+import org.passay.rule.RepeatCharactersRule;
+import org.passay.rule.Rule;
+import org.passay.rule.UsernameRule;
+import org.passay.rule.WhitespaceRule;
+
+/**
+ * Performs a password validation and generation, then dumps the JVM heap.
+ * Execute this class by invoking:
+ * <pre>
+   java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -cp $PATH_TO_DEPENDENCIES org.passay.HeapDump PATH_TO_FILE
+ * </pre>
+ *
+ * @author  Middleware Services
+ */
+public final class HeapDump
+{
+
+
+  /** Default constructor. */
+  private HeapDump() {}
+
+
+  /**
+   * Main method.
+   *
+   * @param  args command line arguments
+   *
+   * @throws  Exception if an error occurs
+   */
+  public static void main(final String[] args)
+    throws Exception
+  {
+    validatePasswords();
+    generatePassword();
+    dumpHeap(args[0], false);
+  }
+
+
+  /**
+   * Performs a password validation.
+   *
+   * @throws  Exception  on error
+   */
+  public static void validatePasswords()
+    throws Exception
+  {
+    final ArrayWordList awl = WordLists.createFromReader(
+      new FileReader[] {new FileReader("src/test/resources/web2-gt3")},
+      false,
+      new ArraysSort());
+    final Dictionary dict = new WordListDictionary(awl);
+
+    final CharacterCharacteristicsRule charRule = new CharacterCharacteristicsRule(
+      3,
+      new CharacterRule(EnglishCharacterData.Digit, 1),
+      new CharacterRule(EnglishCharacterData.Special, 1),
+      new CharacterRule(EnglishCharacterData.UpperCase, 1),
+      new CharacterRule(EnglishCharacterData.LowerCase, 1));
+
+    final WhitespaceRule whitespaceRule = new WhitespaceRule();
+
+    final LengthRule lengthRule = new LengthRule(8, 16);
+
+    final DictionarySubstringRule dictRule = new DictionarySubstringRule(dict, true);
+
+    final IllegalSequenceRule qwertySeqRule = new IllegalSequenceRule(EnglishSequenceData.USQwerty);
+
+    final IllegalSequenceRule alphaSeqRule = new IllegalSequenceRule(EnglishSequenceData.Alphabetical);
+
+    final IllegalSequenceRule numSeqRule = new IllegalSequenceRule(EnglishSequenceData.Numerical);
+
+    final RepeatCharacterRegexRule dupSeqRule = new RepeatCharacterRegexRule();
+
+    final UsernameRule userIDRule = new UsernameRule(true, true);
+
+    final EncodingHashBean sha1Bean = new EncodingHashBean();
+    sha1Bean.setDigestSpec(new DigestSpec("SHA1"));
+    sha1Bean.setCodecSpec(new CodecSpec("Base64"));
+
+    final List<PasswordData.Reference> references = new ArrayList<>();
+    final DigestHistoryRule historyRule = new DigestHistoryRule(sha1Bean);
+    references.add(new PasswordData.HistoricalReference("history", "safx/LW8+SsSy/o3PmCNy4VEm5s="));
+    references.add(new PasswordData.HistoricalReference("history", "zurb9DyQ5nooY1la8h86Bh0n1iw="));
+    references.add(new PasswordData.HistoricalReference("history", "bhqabXwE3S8E6xNJfX/d76MFOCs="));
+
+    final DigestSourceRule sourceRule = new DigestSourceRule(sha1Bean);
+    references.add(new PasswordData.SourceReference("source", "CJGTDMQRP+rmHApkcijC80aDV0o="));
+
+    final AllowedCharacterRule allowedCharacterRule = new AllowedCharacterRule(
+      new UnicodeString(
+        EnglishCharacterData.LowerCase.getCharacters() +
+          EnglishCharacterData.UpperCase.getCharacters() +
+          EnglishCharacterData.Digit.getCharacters()));
+    final IllegalCharacterRule illegalCharacterRule = new IllegalCharacterRule(
+      new UnicodeString('\u0000'));
+    final CharacterOccurrencesRule occurrencesRule = new CharacterOccurrencesRule(3);
+    final LengthComplexityRule lengthComplexityRule = new LengthComplexityRule(
+      new LengthComplexityRule.Entry(
+        "[0,12)",
+        new LengthRule(8, 64),
+        new CharacterCharacteristicsRule(
+          2,
+          new CharacterRule(EnglishCharacterData.Digit, 1),
+          new CharacterRule(EnglishCharacterData.UpperCase, 1),
+          new CharacterRule(EnglishCharacterData.LowerCase, 1))));
+    final NumberRangeRule numberRangeRule = new NumberRangeRule(100, 1000);
+    final RepeatCharactersRule repeatCharactersRule = new RepeatCharactersRule();
+    final AllowedRegexRule allowedRegexRule = new AllowedRegexRule(".*");
+    final IllegalRegexRule illegalRegexRule = new IllegalRegexRule("[\uffff]+");
+
+    final List<Rule> rules = new ArrayList<>();
+    rules.add(charRule);
+    rules.add(whitespaceRule);
+    rules.add(lengthRule);
+    rules.add(dictRule);
+    rules.add(qwertySeqRule);
+    rules.add(alphaSeqRule);
+    rules.add(numSeqRule);
+    rules.add(dupSeqRule);
+    rules.add(userIDRule);
+    rules.add(historyRule);
+    rules.add(sourceRule);
+    rules.add(allowedCharacterRule);
+    rules.add(illegalCharacterRule);
+    rules.add(occurrencesRule);
+    rules.add(lengthComplexityRule);
+    rules.add(numberRangeRule);
+    rules.add(repeatCharactersRule);
+    rules.add(allowedRegexRule);
+    rules.add(illegalRegexRule);
+    final DefaultPasswordValidator validator = new DefaultPasswordValidator(rules);
+    final char[] pass = new char[] {'a', 'B', 'c', 'D', '3', 'F', 'g', 'H', '1', 'J', 'k'};
+    final UnicodeString password = new UnicodeString(pass);
+    final PasswordData passwordData = new PasswordData(new UnicodeString("heapdump"), password, references);
+    try {
+      final ValidationResult result = validator.validate(passwordData);
+      System.out.println(result);
+      printPassword("Validated password", password);
+    } finally {
+      PassayUtils.clear(pass);
+      passwordData.clear();
+    }
+  }
+
+
+  /**
+   * Performs a password generation.
+   */
+  public static void generatePassword()
+  {
+    final PasswordGenerator generator = new PasswordGenerator();
+    final UnicodeString password = generator.generatePassword(
+      22,
+      new CharacterRule(EnglishCharacterData.Digit, 1),
+      new CharacterRule(EnglishCharacterData.UpperCase, 1),
+      new CharacterRule(EnglishCharacterData.LowerCase, 20));
+    try {
+      printPassword("Generated password", password);
+    } finally {
+      password.clear();
+    }
+  }
+
+
+  /**
+   * Dumps the JVM heap to the supplied output file.
+   *
+   * @param  outputFile  to write hprof file to
+   * @param  live  whether to dump only live objects
+   *
+   * @throws  Exception  on error
+   */
+  public static void dumpHeap(final String outputFile, final boolean live)
+    throws Exception
+  {
+    final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    final HotSpotDiagnosticMXBean mxBean = ManagementFactory.newPlatformMXBeanProxy(
+      server, "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
+    mxBean.dumpHeap(outputFile, live);
+  }
+
+
+  /**
+   * Prints a message to {@link System#out} containing the supplied password.
+   *
+   * @param  msg  to prefix password
+   * @param  password  to print as a character array
+   */
+  public static void printPassword(final String msg, final UnicodeString password)
+  {
+    final CharBuffer buffer = password.toCharBuffer();
+    try {
+      System.out.print(msg + ": '");
+      for (char c : buffer.array()) {
+        System.out.print(c);
+      }
+      System.out.println("'");
+    } finally {
+      PassayUtils.clear(buffer);
+    }
+  }
+}

--- a/src/test/java/org/passay/PasswordGeneratorTest.java
+++ b/src/test/java/org/passay/PasswordGeneratorTest.java
@@ -67,8 +67,8 @@ public class PasswordGeneratorTest
     final PasswordGenerator generator = new PasswordGenerator();
     // Perform a number of rounds likely to produce illegal sequences by random chance
     try {
-      for (int i = 0; i < 100000; i++) {
-        final String password = generator.generatePassword(22, ruleSet);
+      for (int i = 0; i < 500000; i++) {
+        final UnicodeString password = generator.generatePassword(22, ruleSet);
         final PasswordData pd = new PasswordData(password);
         assertThat(passValidator.validate(pd).isValid()).isTrue();
         assertThat(failValidator.validate(pd).isValid()).isFalse();

--- a/src/test/java/org/passay/PasswordValidatorTest.java
+++ b/src/test/java/org/passay/PasswordValidatorTest.java
@@ -332,7 +332,7 @@ public class PasswordValidatorTest
 
         /* invalid character rule passwords. */
 
-        /* all digits */
+        // all digits
         {
           validator,
           new PasswordData(USER, "4326789032", references),
@@ -344,7 +344,7 @@ public class PasswordValidatorTest
             EnglishSequenceData.USQwerty.getErrorCode()),
         },
 
-        /* all non-alphanumeric */
+        // all non-alphanumeric
         {
           validator,
           new PasswordData(USER, "$&!$#@*{{>", references),
@@ -355,7 +355,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.LowerCase.getErrorCode()),
         },
 
-        /* all lowercase */
+        // all lowercase
         {
           validator,
           new PasswordData(USER, "aycdopezss", references),
@@ -367,7 +367,7 @@ public class PasswordValidatorTest
             DictionarySubstringRule.ERROR_CODE),
         },
 
-        /* all uppercase */
+        // all uppercase
         {
           validator,
           new PasswordData(USER, "AYCDOPEZSS", references),
@@ -379,7 +379,7 @@ public class PasswordValidatorTest
             DictionarySubstringRule.ERROR_CODE),
         },
 
-        /* digits and non-alphanumeric */
+        // digits and non-alphanumeric
         {
           validator,
           new PasswordData(USER, "@&3*(%5{}^", references),
@@ -389,7 +389,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.LowerCase.getErrorCode()),
         },
 
-        /* digits and lowercase */
+        // digits and lowercase
         {
           validator,
           new PasswordData(USER, "ay3dop5zss", references),
@@ -399,7 +399,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.Special.getErrorCode()),
         },
 
-        /* digits and uppercase */
+        // digits and uppercase
         {
           validator,
           new PasswordData(USER, "AY3DOP5ZSS", references),
@@ -409,7 +409,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.Special.getErrorCode()),
         },
 
-        /* non-alphanumeric and lowercase */
+        // non-alphanumeric and lowercase
         {
           validator,
           new PasswordData(USER, "a&c*o%ea}s", references),
@@ -419,7 +419,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.UpperCase.getErrorCode()),
         },
 
-        /* non-alphanumeric and uppercase */
+        // non-alphanumeric and uppercase
         {
           validator,
           new PasswordData(USER, "A&C*O%EA}S", references),
@@ -429,7 +429,7 @@ public class PasswordValidatorTest
             EnglishCharacterData.LowerCase.getErrorCode()),
         },
 
-        /* uppercase and lowercase */
+        // uppercase and lowercase
         {
           validator,
           new PasswordData(USER, "AycDOPdsyz", references),
@@ -441,7 +441,7 @@ public class PasswordValidatorTest
 
         /* invalid whitespace rule passwords. */
 
-        /* contains a space */
+        // contains a space
         {
           validator,
           new PasswordData(USER, "AycD Pdsyz", references),
@@ -452,7 +452,7 @@ public class PasswordValidatorTest
             WhitespaceRule.ERROR_CODE),
         },
 
-        /* contains a tab */
+        // contains a tab
         {
           validator,
           new PasswordData(USER, "AycD    Psyz", references),
@@ -465,14 +465,14 @@ public class PasswordValidatorTest
 
         /* invalid length rule passwords. */
 
-        /* too short */
+        // too short
         {
           validator,
           new PasswordData(USER, "p4T3t#", references),
           codes(LengthRule.ERROR_CODE_MIN),
         },
 
-        /* too long */
+        // too long
         {
           validator,
           new PasswordData(USER, "p4t3t#n6574632vbad#@!8", references),
@@ -481,14 +481,14 @@ public class PasswordValidatorTest
 
         /* invalid dictionary rule passwords. */
 
-        /* matches dictionary word 'none' */
+        // matches dictionary word 'none'
         {
           validator,
           new PasswordData(USER, "p4t3t#none", references),
           codes(DictionaryRule.ERROR_CODE),
         },
 
-        /* matches dictionary word 'none' backwards */
+        // matches dictionary word 'none' backwards
         {
           validator,
           new PasswordData(USER, "p4t3t#enon", references),
@@ -497,24 +497,21 @@ public class PasswordValidatorTest
 
         /* invalid sequence rule passwords. */
 
-        /* matches sequence 'zxcvb' */
+        // matches sequence 'zxcvb'
         {
           validator,
           new PasswordData(USER, "p4zxcvb#n65", references),
           codes(EnglishSequenceData.USQwerty.getErrorCode()),
         },
 
-        /*
-         * matches sequence 'werty' backwards
-         * 'wert' is a dictionary word
-         */
+       // matches sequence 'werty' backwards; 'wert' is a dictionary word
         {
           validator,
           new PasswordData(USER, "p4ytrew#n65", references),
           codes(EnglishSequenceData.USQwerty.getErrorCode(), DictionaryRule.ERROR_CODE_REVERSED),
         },
 
-        /* matches sequence 'iop[]' ignore case */
+        // matches sequence 'iop[]' ignore case
         {
           validator,
           new PasswordData(USER, "p4iOP[]#n65", references),
@@ -523,30 +520,21 @@ public class PasswordValidatorTest
 
         /* invalid userid rule passwords. */
 
-        /*
-         * contains userid 'testuser'
-         * 'test' and 'user' are dictionary words
-         */
+        // contains userid 'testuser'; 'test' and 'user' are dictionary words
         {
           validator,
           new PasswordData(USER, "p4testuser#n65", references),
           codes(UsernameRule.ERROR_CODE, DictionaryRule.ERROR_CODE),
         },
 
-        /*
-         * contains userid 'testuser' backwards
-         * 'test' and 'user' are dictionary words
-         */
+        // contains userid 'testuser' backwards; 'test' and 'user' are dictionary words
         {
           validator,
           new PasswordData(USER, "p4resutset#n65", references),
           codes(UsernameRule.ERROR_CODE_REVERSED, DictionaryRule.ERROR_CODE_REVERSED),
         },
 
-        /*
-         * contains userid 'testuser' ignore case
-         * 'test' and 'user' are dictionary words
-         */
+        // contains userid 'testuser' ignore case; 'test' and 'user' are dictionary words
         {
           validator,
           new PasswordData(USER, "p4TeStusEr#n65", references),
@@ -555,21 +543,21 @@ public class PasswordValidatorTest
 
         /* invalid history rule passwords. */
 
-        /* contains history password */
+        // contains history password
         {
           validator,
           new PasswordData(USER, "t3stUs3r02", references),
           codes(HistoryRule.ERROR_CODE),
         },
 
-        /* contains history password */
+        // contains history password
         {
           validator,
           new PasswordData(USER, "t3stUs3r03", references),
           codes(HistoryRule.ERROR_CODE),
         },
 
-        /* contains source password */
+        // contains source password
         {
           validator,
           new PasswordData(USER, "t3stUs3r04", references),
@@ -578,35 +566,35 @@ public class PasswordValidatorTest
 
         /* valid passwords. */
 
-        /* digits, non-alphanumeric, lowercase, uppercase */
+        // digits, non-alphanumeric, lowercase, uppercase
         {
           validator,
           new PasswordData(USER, "p4T3t#N65", references),
           null,
         },
 
-        /* digits, non-alphanumeric, lowercase */
+        // digits, non-alphanumeric, lowercase
         {
           validator,
           new PasswordData(USER, "p4t3t#n65", references),
           null,
         },
 
-        /* digits, non-alphanumeric, uppercase */
+        // digits, non-alphanumeric, uppercase
         {
           validator,
           new PasswordData(USER, "P4T3T#N65", references),
           null,
         },
 
-        /* digits, uppercase, lowercase */
+        // digits, uppercase, lowercase
         {
           validator,
           new PasswordData(USER, "p4t3tCn65", references),
           null,
         },
 
-        /* non-alphanumeric, lowercase, uppercase */
+        // non-alphanumeric, lowercase, uppercase
         {
           validator,
           new PasswordData(USER, "pxT%t#Nwq", references),

--- a/src/test/java/org/passay/UnicodeStringTest.java
+++ b/src/test/java/org/passay/UnicodeStringTest.java
@@ -1,0 +1,145 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay;
+
+import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit test for {@link UnicodeString}.
+ *
+ * @author  Middleware Services
+ */
+public class UnicodeStringTest
+{
+
+
+  @Test
+  public void constructor()
+  {
+    try {
+      new UnicodeString((char[]) null);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+    try {
+      new UnicodeString((int[]) null);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+    try {
+      new UnicodeString((String) null);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+    assertThat(new UnicodeString().codePoints()).isEqualTo(new int[0]);
+    assertThat(new UnicodeString("").codePoints()).isEqualTo(new int[0]);
+    assertThat(new UnicodeString(new int[0]).codePoints()).isEqualTo(new int[0]);
+    assertThat(new UnicodeString('A', 'B', 'C').codePoints()).isEqualTo(new int[] {65, 66, 67});
+    assertThat(new UnicodeString('A', '¢', 'C').codePoints()).isEqualTo(new int[] {65, 162, 67});
+    assertThat(new UnicodeString('A', '\u16C8', 'C').codePoints()).isEqualTo(new int[] {65, 5832, 67});
+    assertThat(new UnicodeString('A', '\uD808', '\uDF34', 'C').codePoints()).isEqualTo(new int[] {65, 74548, 67});
+    assertThat(new UnicodeString('A', '\uD83C', '\uDDEE', '\uD83C', '\uDDF8', 'C').codePoints())
+      .isEqualTo(new int[] {65, 127470, 127480, 67});
+    assertThat(new UnicodeString("ABC").codePoints()).isEqualTo(new int[] {65, 66, 67});
+    assertThat(new UnicodeString("A¢C").codePoints()).isEqualTo(new int[] {65, 162, 67});
+    assertThat(new UnicodeString("A\u16C8C").codePoints()).isEqualTo(new int[] {65, 5832, 67});
+    assertThat(new UnicodeString("A\uD808\uDF34C").codePoints()).isEqualTo(new int[] {65, 74548, 67});
+    assertThat(new UnicodeString("A\uD83C\uDDEE\uD83C\uDDF8C").codePoints())
+      .isEqualTo(new int[] {65, 127470, 127480, 67});
+    assertThat(new UnicodeString(65, 66, 67).codePoints()).isEqualTo(new int[] {65, 66, 67});
+  }
+
+
+  @Test
+  public void equals()
+  {
+    assertThat(new UnicodeString('A', 'B', 'C')).isEqualTo(new UnicodeString('A', 'B', 'C'));
+    assertThat(new UnicodeString('A', '¢', 'C')).isEqualTo(new UnicodeString('A', '¢', 'C'));
+    assertThat(new UnicodeString('A', '\u16C8', 'C')).isEqualTo(new UnicodeString('A', '\u16C8', 'C'));
+    assertThat(new UnicodeString('A', '\uD808', '\uDF34', 'C'))
+      .isEqualTo(new UnicodeString('A', '\uD808', '\uDF34', 'C'));
+    assertThat(new UnicodeString('A', '\uD83C', '\uDDEE', '\uD83C', '\uDDF8', 'C'))
+      .isEqualTo(new UnicodeString('A', '\uD83C', '\uDDEE', '\uD83C', '\uDDF8', 'C'));
+    assertThat(new UnicodeString("ABC")).isEqualTo(new UnicodeString("ABC"));
+    assertThat(new UnicodeString("A¢C")).isEqualTo(new UnicodeString("A¢C"));
+    assertThat(new UnicodeString("A\u16C8C")).isEqualTo(new UnicodeString("A\u16C8C"));
+    assertThat(new UnicodeString("A\uD808\uDF34C")).isEqualTo(new UnicodeString("A\uD808\uDF34C"));
+    assertThat(new UnicodeString("A\uD83C\uDDEE\uD83C\uDDF8C"))
+      .isEqualTo(new UnicodeString("A\uD83C\uDDEE\uD83C\uDDF8C"));
+    assertThat(new UnicodeString(65, 66, 67)).isEqualTo(new UnicodeString(65, 66, 67));
+    assertThat(new UnicodeString('A', 'B', 'C')).isNotEqualTo(new UnicodeString('A', 'D', 'C'));
+  }
+
+
+  @Test
+  public void codePointAt()
+  {
+    try {
+      new UnicodeString("ABC123").codePointAt(-1);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+    assertThat(new UnicodeString("ABC123").codePointAt(0)).isEqualTo(65);
+    assertThat(new UnicodeString("ABC123").codePointAt(1)).isEqualTo(66);
+    assertThat(new UnicodeString("ABC123").codePointAt(2)).isEqualTo(67);
+    assertThat(new UnicodeString("ABC123").codePointAt(3)).isEqualTo(49);
+    assertThat(new UnicodeString("ABC123").codePointAt(4)).isEqualTo(50);
+    assertThat(new UnicodeString("ABC123").codePointAt(5)).isEqualTo(51);
+    try {
+      new UnicodeString("ABC123").codePointAt(6);
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+    assertThat(new UnicodeString("ABC\u16C8123").codePointAt(2)).isEqualTo(67);
+    assertThat(new UnicodeString("ABC\u16C8123").codePointAt(3)).isEqualTo(5832);
+    assertThat(new UnicodeString("ABC\u16C8123").codePointAt(4)).isEqualTo(49);
+  }
+
+
+  @Test
+  public void indexOf()
+  {
+    assertThat(new UnicodeString("ABC123").indexOf(new UnicodeString("XYZ"))).isEqualTo(-1);
+    assertThat(new UnicodeString("ABC123").indexOf(new UnicodeString("0123"))).isEqualTo(-1);
+    assertThat(new UnicodeString("ABC123").indexOf(new UnicodeString("123"))).isEqualTo(3);
+    assertThat(new UnicodeString("ABC123").indexOf(new UnicodeString("C1"))).isEqualTo(2);
+    assertThat(new UnicodeString("ABC\u16C8123").indexOf(new UnicodeString("\u16C8"))).isEqualTo(3);
+    assertThat(new UnicodeString("ABC\u16C8123").indexOf(new UnicodeString("C\u16C81"))).isEqualTo(2);
+    assertThat(new UnicodeString("ABC\u16C8123").indexOf(new UnicodeString("\u16C9"))).isEqualTo(-1);
+  }
+
+
+  @Test
+  public void startsWith()
+  {
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("A"))).isTrue();
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("AB"))).isTrue();
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("ABC"))).isTrue();
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("BC"))).isFalse();
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("123"))).isFalse();
+    assertThat(new UnicodeString("ABC123").startsWith(new UnicodeString("XYZ"))).isFalse();
+    assertThat(new UnicodeString("¢BC123").startsWith(new UnicodeString('¢'))).isTrue();
+    assertThat(new UnicodeString("¢BC123").startsWith(new UnicodeString('¢', 'B'))).isTrue();
+    assertThat(new UnicodeString("¢BC123").startsWith(new UnicodeString(162))).isTrue();
+  }
+
+
+  @Test
+  public void endsWith()
+  {
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("3"))).isTrue();
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("23"))).isTrue();
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("123"))).isTrue();
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("12"))).isFalse();
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("ABC"))).isFalse();
+    assertThat(new UnicodeString("ABC123").endsWith(new UnicodeString("XYZ"))).isFalse();
+    assertThat(new UnicodeString("ABC12¢").endsWith(new UnicodeString('¢'))).isTrue();
+    assertThat(new UnicodeString("ABC12¢").endsWith(new UnicodeString('2', '¢'))).isTrue();
+    assertThat(new UnicodeString("ABC12¢").endsWith(new UnicodeString(162))).isTrue();
+  }
+}

--- a/src/test/java/org/passay/dictionary/BloomFilterDictionaryTest.java
+++ b/src/test/java/org/passay/dictionary/BloomFilterDictionaryTest.java
@@ -40,7 +40,7 @@ public class BloomFilterDictionaryTest extends AbstractDictionaryTest
   @BeforeClass(groups = "bloomdicttest")
   public void createDictionary(final String dict) throws Exception
   {
-    final BloomFilter<String> filter1 = BloomFilter.readFrom(
+    final BloomFilter<CharSequence> filter1 = BloomFilter.readFrom(
       Files.newInputStream(Paths.get(dict)), Funnels.stringFunnel(StandardCharsets.UTF_8));
     filterFromSerialized = new BloomFilterDictionary(filter1);
 
@@ -48,7 +48,7 @@ public class BloomFilterDictionaryTest extends AbstractDictionaryTest
       new FileReader[] {new FileReader(webFile)},
       true,
       new ArraysSort());
-    final BloomFilter<String> filter2 = BloomFilter.create(
+    final BloomFilter<CharSequence> filter2 = BloomFilter.create(
       Funnels.stringFunnel(StandardCharsets.UTF_8), awl.size(), 0.0001);
     for (int i = 0; i < awl.size(); i++) {
       filter2.put(awl.get(i));

--- a/src/test/java/org/passay/dictionary/TernaryTreeTest.java
+++ b/src/test/java/org/passay/dictionary/TernaryTreeTest.java
@@ -133,7 +133,7 @@ public class TernaryTreeTest
   @Test(groups = "tttest", dataProvider = "partialSearchData")
   public void partialSearch(final TernaryTree tt, final String searchTerm, final String[] expected)
   {
-    final String[] actual = tt.partialSearch(searchTerm);
+    final CharSequence[] actual = tt.partialSearch(searchTerm);
     System.out.println("Partial search results: " + Arrays.toString(actual));
     System.out.println("Partial search expected: " + Arrays.toString(expected));
     assertThat(actual).isEqualTo(expected);
@@ -149,7 +149,7 @@ public class TernaryTreeTest
   @Test(groups = "tttest", dataProvider = "nearSearchData")
   public void nearSearch(final TernaryTree tt, final String word, final int distance, final String[] expected)
   {
-    final String[] actual = tt.nearSearch(word, distance);
+    final CharSequence[] actual = tt.nearSearch(word, distance);
     System.out.println("Near search results: " + Arrays.toString(actual));
     System.out.println("Near search expected: " + Arrays.toString(expected));
     assertThat(actual).isEqualTo(expected);

--- a/src/test/java/org/passay/dictionary/WordListsTest.java
+++ b/src/test/java/org/passay/dictionary/WordListsTest.java
@@ -93,7 +93,7 @@ public class WordListsTest
 
 
   /**
-   * Test for {@link WordLists#binarySearch(WordList, String)}.
+   * Test for {@link WordLists#binarySearch(WordList, CharSequence)}.
    *
    * @param  wl  Test word list.
    * @param  word  Word to search for.

--- a/src/test/java/org/passay/rule/AbstractRuleTest.java
+++ b/src/test/java/org/passay/rule/AbstractRuleTest.java
@@ -41,7 +41,9 @@ public abstract class AbstractRuleTest
     final RuleResult result = rule.validate(passwordData);
     if (errorCodes != null) {
       assertThat(result.isValid()).isFalse();
-      assertThat(result.getDetails().size()).isEqualTo(errorCodes.length);
+      assertThat(result.getDetails().size())
+        .withFailMessage("Found details: %s", result.getDetails())
+        .isEqualTo(errorCodes.length);
       for (String code : errorCodes) {
         assertThat(hasErrorCode(code, result)).isTrue();
       }

--- a/src/test/java/org/passay/rule/CharacterRuleTest.java
+++ b/src/test/java/org/passay/rule/CharacterRuleTest.java
@@ -1,0 +1,115 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.rule;
+
+import org.passay.PasswordData;
+import org.passay.data.EnglishCharacterData;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link CharacterRule}.
+ *
+ * @author  Middleware Services
+ */
+public class CharacterRuleTest extends AbstractRuleTest
+{
+
+
+  /**
+   * @return  Test data.
+   */
+  @DataProvider(name = "passwords")
+  public Object[][] passwords()
+  {
+    return
+      new Object[][] {
+
+        // test valid password
+        {new CharacterRule(EnglishCharacterData.LowerCase, 5), new PasswordData("bo3p$elW3ZZ"), null, },
+        {new CharacterRule(EnglishCharacterData.UpperCase, 2), new PasswordData("bo3p$elW3ZZ"), null, },
+        {new CharacterRule(EnglishCharacterData.Digit, 1), new PasswordData("bo3p$elW3ZZ"), null, },
+        {new CharacterRule(EnglishCharacterData.SpecialAscii, 1), new PasswordData("bo3p$elW3ZZ"), null, },
+        // test invalid password
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$elW3ZZ"),
+          EnglishCharacterData.LowerCase.getErrorCode(),
+        },
+        {
+          new CharacterRule(EnglishCharacterData.UpperCase, 5),
+          new PasswordData("bo3p$elW3ZZ"),
+          EnglishCharacterData.UpperCase.getErrorCode(),
+        },
+        {
+          new CharacterRule(EnglishCharacterData.Digit, 3),
+          new PasswordData("bo3p$elW3ZZ"),
+          EnglishCharacterData.Digit.getErrorCode(),
+        },
+        {
+          new CharacterRule(EnglishCharacterData.SpecialAscii, 2),
+          new PasswordData("bo3p$elW3ZZ"),
+          EnglishCharacterData.SpecialAscii.getErrorCode(),
+        },
+        // test unicode
+        {new CharacterRule(EnglishCharacterData.LowerCase, 4), new PasswordData("bo3p$ečW3ZZ"), null, },
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$ečW3ZZ"),
+          EnglishCharacterData.LowerCase.getErrorCode(),
+        },
+        {new CharacterRule(EnglishCharacterData.LowerCase, 4), new PasswordData("bo3p$e\u16C8W3ZZ"), null, },
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$e\u16C8W3ZZ"),
+          EnglishCharacterData.LowerCase.getErrorCode(),
+        },
+        {new CharacterRule(EnglishCharacterData.LowerCase, 4), new PasswordData("bo3p$e\uD808\uDF34W3ZZ"), null, },
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$e\uD808\uDF34W3ZZ"),
+          EnglishCharacterData.LowerCase.getErrorCode(),
+        },
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 4),
+          new PasswordData("bo3p$e\uD83C\uDDEE\uD83C\uDDF8W3ZZ"),
+          null,
+        },
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$e\uD83C\uDDEE\uD83C\uDDF8W3ZZ"),
+          EnglishCharacterData.LowerCase.getErrorCode(),
+        },
+      };
+  }
+
+
+  /**
+   * @return  Test data.
+   */
+  @DataProvider(name = "messages")
+  public Object[][] messages()
+  {
+    return
+      new Object[][] {
+        {
+          new CharacterRule(EnglishCharacterData.LowerCase, 15),
+          new PasswordData("bo3p$elW3ZZ"),
+          new String[] {String.format("Password must contain %s or more lowercase characters.", "15"), },
+        },
+        {
+          new CharacterRule(EnglishCharacterData.UpperCase, 5),
+          new PasswordData("bo3p$elW3ZZ"),
+          new String[] {String.format("Password must contain %s or more uppercase characters.", "5"), },
+        },
+        {
+          new CharacterRule(EnglishCharacterData.Digit, 3),
+          new PasswordData("bo3p$elW3ZZ"),
+          new String[] {String.format("Password must contain %s or more digit characters.", "3"), },
+        },
+        {
+          new CharacterRule(EnglishCharacterData.SpecialAscii, 2),
+          new PasswordData("bo3p$elW3ZZ"),
+          new String[] {String.format("Password must contain %s or more special characters.", "2"), },
+        },
+      };
+  }
+}

--- a/src/test/testng/testng.xml
+++ b/src/test/testng/testng.xml
@@ -31,22 +31,15 @@
 
   <parameter name="bloomFile" value="src/test/resources/bloom.bin"/>
 
-  <test name="coretests" parallel="methods" thread-count="2">
+  <test name="tests" parallel="methods" thread-count="2">
     <groups>
-      <run>
+      <define name="core">
         <include name="passtest" />
         <include name="entrpytest" />
         <include name="passgentest" />
         <include name="seqperftest" />
-      </run>
-    </groups>
-    <packages>
-      <package name="org.passay.*" />
-    </packages>
-  </test>
-  <test name="dicttests" parallel="methods" thread-count="6">
-    <groups>
-      <run>
+      </define>
+      <define name="dict">
         <include name="wltest" />
         <include name="tttest" />
         <include name="sorttest" />
@@ -54,21 +47,19 @@
         <include name="ttdicttest" />
         <include name="jdbcdicttest" />
         <include name="bloomdicttest" />
-      </run>
-    </groups>
-    <packages>
-      <package name="org.passay.dictionary.*" />
-    </packages>
-  </test>
-  <test name="dictperftests" parallel="methods" thread-count="6">
-    <groups>
-      <run>
+      </define>
+      <define name="dictperf">
         <include name="ttperftest" />
         <include name="wlperftest" />
+      </define>
+      <run>
+        <include name="core"/>
+        <include name="dict"/>
+        <include name="dictperf"/>
       </run>
     </groups>
     <packages>
-      <package name="org.passay.dictionary.*" />
+      <package name="org.passay.*" />
     </packages>
   </test>
 </suite>


### PR DESCRIPTION
Prefer the use of CharSequence and CharBuffer in the API over String. Write zeros to any buffers or arrays created by implementations. Expand use of UnicodeString in the API in place of String. Improve UnicodeString to support common string operations. Add support for producing and testing heap dumps.
Add unit tests for UnicodeString and CharacterRule. Fixes #126.