### PR TITLE
v2: Improve PasswordGenerator

### DIFF
--- a/src/main/java/org/passay/AbstractValidationResult.java
+++ b/src/main/java/org/passay/AbstractValidationResult.java
@@ -84,4 +84,16 @@ public abstract class AbstractValidationResult implements ValidationResult
   {
     return Collections.emptyList();
   }
+
+
+  @Override
+  public String toString()
+  {
+    return getClass().getName() + "@" + hashCode() + "::" +
+      "valid=" + isValid() + ", " +
+      "details=" + getDetails() + ", " +
+      "metadata=" + getMetadata() + ", " +
+      "entropy=" + getEntropy() + ", " +
+      "messages=" + getMessages();
+  }
 }

--- a/src/main/java/org/passay/PassayUtils.java
+++ b/src/main/java/org/passay/PassayUtils.java
@@ -8,6 +8,7 @@ import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Random;
 import java.util.function.Predicate;
 
 /**
@@ -180,6 +181,29 @@ public final class PassayUtils
       ((Buffer) o).flip();
     } else {
       throw new IllegalArgumentException("Unsupported type: " + o.getClass().getName());
+    }
+  }
+
+
+  /**
+   * Appends characters to the supplied target with count random characters from source.
+   *
+   * @param  source  of random characters.
+   * @param  target  character sequence that will hold characters.
+   * @param  count  number of random characters.
+   * @param  rand  to select characters from source.
+   */
+  public static void appendRandomCharacters(
+    final UnicodeString source, final CharBuffer target, final int count, final Random rand)
+  {
+    if (source == null || source.isEmpty()) {
+      return;
+    }
+    for (int i = 0; i < count; i++) {
+      final String s = PassayUtils.toString(source.codePointAt(rand.nextInt(source.length())));
+      if (target.position() + s.length() <= target.limit()) {
+        target.append(s);
+      }
     }
   }
 }

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -187,7 +187,7 @@ public class PasswordGenerator
     final UnicodeString fillChars;
     if (!allowedChars.isEmpty()) {
       if (!illegalChars.isEmpty()) {
-        fillChars = allowedChars.difference(illegalChars, true);
+        fillChars = allowedChars.difference(illegalChars);
       } else {
         fillChars = allowedChars;
       }
@@ -196,7 +196,7 @@ public class PasswordGenerator
       final UnicodeString chars = getCharacters(rules);
       if (!chars.isEmpty()) {
         if (!illegalChars.isEmpty()) {
-          fillChars = chars.difference(illegalChars, true);
+          fillChars = chars.difference(illegalChars);
         } else {
           fillChars = chars;
         }
@@ -259,7 +259,7 @@ public class PasswordGenerator
     if (!characterRules.isEmpty()) {
       chars = new UnicodeString(characterRules.get(0).getValidCharacters());
       for (int i = 1; i < characterRules.size(); i++) {
-        chars = chars.union(new UnicodeString(characterRules.get(i).getValidCharacters()), true);
+        chars = chars.union(new UnicodeString(characterRules.get(i).getValidCharacters()));
       }
     }
     return chars != null ? chars : new UnicodeString();
@@ -282,7 +282,7 @@ public class PasswordGenerator
         if (allowedChars == null) {
           allowedChars = ((AllowedCharacterRule) rule).getAllowedCharacters();
         } else {
-          allowedChars = allowedChars.intersection(((AllowedCharacterRule) rule).getAllowedCharacters(), true);
+          allowedChars = allowedChars.intersection(((AllowedCharacterRule) rule).getAllowedCharacters());
         }
       }
     }
@@ -305,7 +305,7 @@ public class PasswordGenerator
         if (illegalChars == null) {
           illegalChars = ((IllegalCharacterRule) rule).getIllegalCharacters();
         } else {
-          illegalChars = illegalChars.union(((IllegalCharacterRule) rule).getIllegalCharacters(), true);
+          illegalChars = illegalChars.union(((IllegalCharacterRule) rule).getIllegalCharacters());
         }
       }
     }
@@ -378,7 +378,7 @@ public class PasswordGenerator
     {
       UnicodeString characters = appenders.get(0).getCharacters();
       for (int i = 1; i < appenders.size(); i++) {
-        characters = characters.union(appenders.get(i).getCharacters(), true);
+        characters = characters.union(appenders.get(i).getCharacters());
       }
       return characters;
     }
@@ -423,10 +423,10 @@ public class PasswordGenerator
       numberOfCharacters = rule.getNumberOfCharacters();
       UnicodeString validChars = new UnicodeString(rule.getValidCharacters());
       if (!allowedChars.isEmpty()) {
-        validChars = validChars.intersection(allowedChars, true);
+        validChars = validChars.intersection(allowedChars);
       }
       if (!illegalChars.isEmpty()) {
-        validChars = validChars.difference(illegalChars, true);
+        validChars = validChars.difference(illegalChars);
       }
       characters = validChars;
       random = rand;

--- a/src/main/java/org/passay/PasswordGenerator.java
+++ b/src/main/java/org/passay/PasswordGenerator.java
@@ -6,11 +6,16 @@ import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.passay.rule.AllowedCharacterRule;
+import org.passay.rule.CharacterCharacteristicsRule;
 import org.passay.rule.CharacterRule;
+import org.passay.rule.IllegalCharacterRule;
 import org.passay.rule.Rule;
 
 /**
@@ -30,25 +35,85 @@ public class PasswordGenerator
   /** Source of random data. */
   private final Random random;
 
+  /** Length of passwords to generate. */
+  private final int length;
+
+  /** Rules to determine password character appenders. */
+  private final List<Rule> passwordRules = new ArrayList<>();
+
+  /** Character appenders derived from the rules. */
+  private final List<CharacterAppender> characterAppenders = new ArrayList<>();
+
+  /** Valid characters used to satisfy the requested password length. */
+  private final UnicodeString fillCharacters;
+
   /** Tracks the total number of retries. */
   private int retryCount;
 
 
-  /** Default constructor. Instantiates a secure random for password generation. */
-  public PasswordGenerator()
+  /**
+   * Creates a new password generator.
+   *
+   * @param  length  of the password to generate
+   * @param  rules  to govern the content of the password
+   */
+  public PasswordGenerator(final int length, final Rule... rules)
   {
-    this(new SecureRandom());
+    this(new SecureRandom(), length, Arrays.asList(rules));
   }
 
 
   /**
-   * Creates a new password generator with the supplied random.
+   * Creates a new password generator.
    *
-   * @param  r  random
+   * @param  length  of the password to generate
+   * @param  rules  to govern the content of the password
    */
-  public PasswordGenerator(final Random r)
+  public PasswordGenerator(final int length, final List<? extends Rule> rules)
   {
-    random = PassayUtils.assertNotNullArg(r, "Random cannot be null");
+    this(new SecureRandom(), length, rules);
+  }
+
+
+  /**
+   * Creates a new password generator.
+   *
+   * @param  random  for ordering of password characters
+   * @param  length  of the password to generate
+   * @param  rules  to govern the content of the password
+   */
+  public PasswordGenerator(final Random random, final int length, final List<? extends Rule> rules)
+  {
+    if (length <= 0) {
+      throw new IllegalArgumentException("Length must be greater than 0");
+    }
+    if (length > MAX_PASSWORD_LENGTH) {
+      throw new IllegalArgumentException("Length must be less than " + MAX_PASSWORD_LENGTH);
+    }
+    PassayUtils.assertNotNullArgOr(
+      rules,
+      v -> Stream.of(rules).anyMatch(Objects::isNull),
+      "Rules cannot be null or contain null");
+    this.random = PassayUtils.assertNotNullArg(random, "Random cannot be null");
+    this.length = length;
+
+    // characters defined in all AllowedCharacterRules
+    final UnicodeString allowedChars = getAllowedCharacters(rules);
+    // characters defined in all IllegalCharacterRules
+    final UnicodeString illegalChars = getIllegalCharacters(rules);
+    // valid characters used to fill the generated password
+    this.fillCharacters = getFillCharacters(rules, allowedChars, illegalChars);
+    if (this.fillCharacters.isEmpty()) {
+      throw new IllegalArgumentException("Rules did not produce any combination of valid characters");
+    }
+
+    this.characterAppenders.addAll(getCharacterAppenders(rules, allowedChars, illegalChars, this.random));
+    if (this.characterAppenders.isEmpty() ||
+        this.characterAppenders.stream().allMatch(c -> c.getCharacters().isEmpty()))
+    {
+      throw new IllegalArgumentException("Rules did not produce any combination of valid characters");
+    }
+    this.passwordRules.addAll(rules);
   }
 
 
@@ -65,66 +130,22 @@ public class PasswordGenerator
 
 
   /**
-   * See {@link #generatePassword(int, List)}.
-   *
-   * @param  <T>  type of rule
-   * @param  length  of password to generate
-   * @param  rules  to generate compliant password from
+   * Generates a new password of the configured length which meets the requirements of the configured rules.
    *
    * @return  generated password
    */
-  @SuppressWarnings("unchecked")
-  public <T extends Rule> UnicodeString generatePassword(final int length, final T... rules)
+  public UnicodeString generate()
   {
-    PassayUtils.assertNotNullArgOr(
-      rules,
-      v -> Stream.of(rules).anyMatch(Objects::isNull),
-      "Rules cannot be null or contain null");
-    return generatePassword(length, Arrays.asList(rules));
-  }
-
-
-  /**
-   * Generates a password of the supplied length which meets the requirements of the supplied character rules. For
-   * length to be evaluated it must be greater than the number of characters defined in the character rule.
-   *
-   * @param  length  of password to generate
-   * @param  rules  to generate compliant password from
-   *
-   * @return  generated password
-   */
-  public UnicodeString generatePassword(final int length, final List<? extends Rule> rules)
-  {
-    if (length <= 0) {
-      throw new IllegalArgumentException("Length must be greater than 0");
-    }
-    if (length > MAX_PASSWORD_LENGTH) {
-      throw new IllegalArgumentException("Length must be less than " + MAX_PASSWORD_LENGTH);
-    }
-    PassayUtils.assertNotNullArgOr(
-      rules,
-      v -> v.stream().anyMatch(Objects::isNull),
-      "Rules cannot be null or contain null");
-
-    final StringBuilder allChars = new StringBuilder();
     final CharBuffer buffer = CharBuffer.allocate(length);
     UnicodeString generated;
     int count = 0;
-
     do {
-      for (Rule rule : rules) {
-        if (rule instanceof CharacterRule) {
-          final CharacterRule characterRule = (CharacterRule) rule;
-          fillRandomCharacters(
-            characterRule.getValidCharacters(),
-            Math.min(length, characterRule.getNumberOfCharacters()),
-            buffer);
-          if (count == 0) {
-            allChars.append(characterRule.getValidCharacters());
-          }
-        }
+      for (CharacterAppender appender : characterAppenders) {
+        // for each rule append characters that satisfy the rule
+        appender.append(buffer, length);
       }
-      fillRandomCharacters(allChars.toString(), length - buffer.position(), buffer);
+      // fill any additional characters needed to satisfy the length of the password
+      PassayUtils.appendRandomCharacters(fillCharacters, buffer, length - buffer.position(), random);
       // cast to Buffer prevents NoSuchMethodError when compiled on JDK9+ and run on JDK8
       ((Buffer) buffer).flip();
       randomize(buffer);
@@ -132,7 +153,7 @@ public class PasswordGenerator
       if (count > 0) {
         retryCount++;
       }
-      final DefaultPasswordValidator validator = new DefaultPasswordValidator(rules);
+      final DefaultPasswordValidator validator = new DefaultPasswordValidator(passwordRules);
       if (validator.validate(new PasswordData(generated)).isValid()) {
         break;
       } else {
@@ -151,29 +172,151 @@ public class PasswordGenerator
   }
 
 
-  @Override
-  public String toString()
+  /**
+   * Returns the fill characters used to populate a generated password.
+   *
+   * @param  rules  to derive characters from
+   * @param  allowedChars  characters allowed
+   * @param  illegalChars  characters not allowed
+   *
+   * @return  fill characters
+   */
+  protected UnicodeString getFillCharacters(
+    final List<? extends Rule> rules, final  UnicodeString allowedChars, final UnicodeString illegalChars)
   {
-    return getClass().getName() + "@" + hashCode() + "::retryCount=" + retryCount;
+    final UnicodeString fillChars;
+    if (!allowedChars.isEmpty()) {
+      if (!illegalChars.isEmpty()) {
+        fillChars = allowedChars.difference(illegalChars, true);
+      } else {
+        fillChars = allowedChars;
+      }
+    } else {
+      // characters defined in all CharacterRules
+      final UnicodeString chars = getCharacters(rules);
+      if (!chars.isEmpty()) {
+        if (!illegalChars.isEmpty()) {
+          fillChars = chars.difference(illegalChars, true);
+        } else {
+          fillChars = chars;
+        }
+      } else {
+        fillChars = new UnicodeString();
+      }
+    }
+    return fillChars;
   }
 
 
   /**
-   * Fills the supplied target with count random characters from source.
+   * Returns the list of character appenders used for password generation.
    *
-   * @param  source  of random characters.
-   * @param  count  number of random characters.
-   * @param  target  character sequence that will hold characters.
+   * @param  rules  to derive password characters
+   * @param  allowedChars  characters allowed
+   * @param  illegalChars  characters not allowed
+   * @param  rand  to randomize character selection
+   *
+   * @return  character appenders
    */
-  protected void fillRandomCharacters(final String source, final int count, final CharBuffer target)
+  protected List<CharacterAppender> getCharacterAppenders(
+    final List<? extends Rule> rules,
+    final UnicodeString allowedChars,
+    final UnicodeString illegalChars,
+    final Random rand)
   {
-    final int[] indexes = codePointIndexes(source);
-    for (int i = 0; i < count; i++) {
-      final String s = PassayUtils.toString(source.codePointAt(indexes[random.nextInt(indexes.length)]));
-      if (target.position() + s.length() <= target.limit()) {
-        target.append(s);
+    final List<CharacterAppender> appenders = new ArrayList<>();
+    for (Rule rule : rules) {
+      if (rule instanceof CharacterRule) {
+        appenders.add(new CharacterRuleAppender((CharacterRule) rule, allowedChars, illegalChars, rand));
+      } else if (rule instanceof CharacterCharacteristicsRule) {
+        appenders.add(
+          new CharacterCharacteristicsAppender((CharacterCharacteristicsRule) rule, allowedChars, illegalChars, rand));
       }
     }
+    return appenders;
+  }
+
+
+  /**
+   * Return a unicode string that contains the unique characters from all {@link CharacterRule} or
+   * {@link CharacterCharacteristicsRule} contained in the supplied list.
+   *
+   * @param  rules  to extract unique characters from
+   *
+   * @return  unicode string containing unique characters or empty string
+   */
+  private UnicodeString getCharacters(final List<? extends Rule> rules)
+  {
+    final List<CharacterRule> characterRules = new ArrayList<>();
+    for (Rule rule : rules) {
+      if (rule instanceof CharacterRule) {
+        characterRules.add((CharacterRule) rule);
+      } else if (rule instanceof CharacterCharacteristicsRule) {
+        characterRules.addAll(((CharacterCharacteristicsRule) rule).getRules());
+      }
+    }
+    UnicodeString chars = null;
+    if (!characterRules.isEmpty()) {
+      chars = new UnicodeString(characterRules.get(0).getValidCharacters());
+      for (int i = 1; i < characterRules.size(); i++) {
+        chars = chars.union(new UnicodeString(characterRules.get(i).getValidCharacters()), true);
+      }
+    }
+    return chars != null ? chars : new UnicodeString();
+  }
+
+
+  /**
+   * Returns the unique set of allowed characters as defined in the supplied list of {@link AllowedCharacterRule}. These
+   * are the characters that are common to every rule in the list.
+   *
+   * @param  rules  to extract unique characters from
+   *
+   * @return  unicode string containing unique characters or empty string
+   */
+  private UnicodeString getAllowedCharacters(final List<? extends Rule> rules)
+  {
+    UnicodeString allowedChars = null;
+    for (Rule rule : rules) {
+      if (rule instanceof AllowedCharacterRule) {
+        if (allowedChars == null) {
+          allowedChars = ((AllowedCharacterRule) rule).getAllowedCharacters();
+        } else {
+          allowedChars = allowedChars.intersection(((AllowedCharacterRule) rule).getAllowedCharacters(), true);
+        }
+      }
+    }
+    return allowedChars != null ? allowedChars : new UnicodeString();
+  }
+
+
+  /**
+   * Returns the unique set of illegal characters as defined in the supplied list of {@link IllegalCharacterRule}.
+   *
+   * @param  rules  to extract unique characters from
+   *
+   * @return  unicode string containing unique characters or empty string
+   */
+  private UnicodeString getIllegalCharacters(final List<? extends Rule> rules)
+  {
+    UnicodeString illegalChars = null;
+    for (Rule rule : rules) {
+      if (rule instanceof IllegalCharacterRule) {
+        if (illegalChars == null) {
+          illegalChars = ((IllegalCharacterRule) rule).getIllegalCharacters();
+        } else {
+          illegalChars = illegalChars.union(((IllegalCharacterRule) rule).getIllegalCharacters(), true);
+        }
+      }
+    }
+    return illegalChars != null ?  illegalChars : new UnicodeString();
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return getClass().getName() + "@" + hashCode() + "::retryCount=" + retryCount;
   }
 
 
@@ -195,24 +338,135 @@ public class PasswordGenerator
   }
 
 
-  /**
-   * Returns the indexes for every code point in the supplied string.
-   *
-   * @param  s  to find code point indexes
-   *
-   * @return  array of code point indexes
-   */
-  private static int[] codePointIndexes(final String s)
+  /** Character appender for {@link CharacterCharacteristicsRule}. */
+  public static class CharacterCharacteristicsAppender implements CharacterAppender
   {
-    if (s == null || s.isEmpty()) {
-      return new int[0];
+    /** Number of characteristics. */
+    private final int numberOfCharacteristics;
+
+    /** Character rule appenders. */
+    private final List<CharacterRuleAppender> appenders;
+
+    /** To select random characters. */
+    private final Random random;
+
+
+    /**
+     * Creates a new character characteristics appender.
+     *
+     * @param  rule  to build appender from
+     * @param  allowedChars  characters allowed in password generation
+     * @param  illegalChars  characters not allowed in password generation
+     * @param  rand  to randomize character selection
+     */
+    public CharacterCharacteristicsAppender(
+      final CharacterCharacteristicsRule rule,
+      final UnicodeString allowedChars,
+      final UnicodeString illegalChars,
+      final Random rand)
+    {
+      numberOfCharacteristics = rule.getNumberOfCharacteristics();
+      appenders = rule.getRules().stream()
+        .map(r -> new CharacterRuleAppender(r, allowedChars, illegalChars, rand))
+        .collect(Collectors.toList());
+      random = rand;
     }
-    final List<Integer> indexes = new ArrayList<>(PassayUtils.codePointCount(s));
-    int i = 0;
-    while (i < s.length()) {
-      indexes.add(i);
-      i += Character.charCount(s.codePointAt(i));
+
+
+    @Override
+    public UnicodeString getCharacters()
+    {
+      UnicodeString characters = appenders.get(0).getCharacters();
+      for (int i = 1; i < appenders.size(); i++) {
+        characters = characters.union(appenders.get(i).getCharacters(), true);
+      }
+      return characters;
     }
-    return indexes.stream().mapToInt(Integer::intValue).toArray();
+
+
+    @Override
+    public void append(final CharBuffer target, final int count)
+    {
+      final List<CharacterRuleAppender> randomAppender = new ArrayList<>(appenders);
+      Collections.shuffle(randomAppender, random);
+      for (int i = 0; i < numberOfCharacteristics; i++) {
+        randomAppender.get(i).append(target, count);
+      }
+    }
+  }
+
+
+  /** Character appender for {@link CharacterRule}. */
+  public static class CharacterRuleAppender implements CharacterAppender
+  {
+    /** Number of characters. */
+    private final int numberOfCharacters;
+
+    /** Valid characters. */
+    private final UnicodeString characters;
+
+    /** To select random characters. */
+    private final Random random;
+
+
+    /**
+     * Creates a new character rule appender.
+     *
+     * @param  rule  to build appender from
+     * @param  allowedChars  characters allowed for appending
+     * @param  illegalChars  characters not allowed for appending
+     * @param  rand  to randomize character selection
+     */
+    public CharacterRuleAppender(
+      final CharacterRule rule, final UnicodeString allowedChars, final UnicodeString illegalChars, final Random rand)
+    {
+      numberOfCharacters = rule.getNumberOfCharacters();
+      UnicodeString validChars = new UnicodeString(rule.getValidCharacters());
+      if (!allowedChars.isEmpty()) {
+        validChars = validChars.intersection(allowedChars, true);
+      }
+      if (!illegalChars.isEmpty()) {
+        validChars = validChars.difference(illegalChars, true);
+      }
+      characters = validChars;
+      random = rand;
+    }
+
+
+    @Override
+    public UnicodeString getCharacters()
+    {
+      return characters;
+    }
+
+
+    @Override
+    public void append(final CharBuffer target, final int count)
+    {
+      PassayUtils.appendRandomCharacters(characters, target, Math.min(count, numberOfCharacters), random);
+    }
+  }
+
+
+  /** Interface for appending characters. */
+  public interface CharacterAppender
+  {
+
+
+    /**
+     * Returns the characters that may be used in by this appender.
+     *
+     * @return  valid characters
+     */
+    UnicodeString getCharacters();
+
+
+    /**
+     * Fills the target buffer with count characters from this appender.
+     *
+     * @param  target  buffer to add characters to
+     * @param  count  number of characters to add to buffer
+     */
+    void append(CharBuffer target, int count);
   }
 }

--- a/src/main/java/org/passay/UnicodeString.java
+++ b/src/main/java/org/passay/UnicodeString.java
@@ -338,34 +338,13 @@ public final class UnicodeString implements CharSequence
    */
   public UnicodeString intersection(final UnicodeString other)
   {
-    return intersection(other, false);
-  }
-
-
-  /**
-   * Returns the intersection of this string and the other string. Intersection is defined as the unique set of code
-   * points that both strings have in common.
-   *
-   * @param  other  string to intersect
-   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
-   *
-   * @return  new unicode string
-   */
-  public UnicodeString intersection(final UnicodeString other, final boolean clear)
-  {
-    try {
-      final Set<Integer> intersection = new LinkedHashSet<>();
-      for (int cp : codePoints) {
-        if (other.indexOf(cp) != -1) {
-          intersection.add(cp);
-        }
-      }
-      return new UnicodeString(intersection.stream().mapToInt(Integer::intValue).toArray());
-    } finally {
-      if (clear) {
-        clear();
+    final Set<Integer> intersection = new LinkedHashSet<>();
+    for (int cp : codePoints) {
+      if (other.indexOf(cp) != -1) {
+        intersection.add(cp);
       }
     }
+    return new UnicodeString(intersection.stream().mapToInt(Integer::intValue).toArray());
   }
 
 
@@ -379,35 +358,14 @@ public final class UnicodeString implements CharSequence
    */
   public UnicodeString union(final UnicodeString other)
   {
-    return union(other, false);
-  }
-
-
-  /**
-   * Returns the union of this string and the other string. Union is defined as the unique set of code points in either
-   * string.
-   *
-   * @param  other  string to intersect
-   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
-   *
-   * @return  new unicode string
-   */
-  public UnicodeString union(final UnicodeString other, final boolean clear)
-  {
-    try {
-      final Set<Integer> union = new LinkedHashSet<>();
-      for (int cp : codePoints) {
-        union.add(cp);
-      }
-      for (int cp : other.toCodePointArray()) {
-        union.add(cp);
-      }
-      return new UnicodeString(union.stream().mapToInt(Integer::intValue).toArray());
-    } finally {
-      if (clear) {
-        clear();
-      }
+    final Set<Integer> union = new LinkedHashSet<>();
+    for (int cp : codePoints) {
+      union.add(cp);
     }
+    for (int cp : other.toCodePointArray()) {
+      union.add(cp);
+    }
+    return new UnicodeString(union.stream().mapToInt(Integer::intValue).toArray());
   }
 
 
@@ -421,34 +379,13 @@ public final class UnicodeString implements CharSequence
    */
   public UnicodeString difference(final UnicodeString other)
   {
-    return difference(other, false);
-  }
-
-
-  /**
-   * Returns the difference of this string and the other string. Difference is defined as the unique set of code points
-   * that are in this string but not in the other string.
-   *
-   * @param  other  string to difference
-   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
-   *
-   * @return  new unicode string
-   */
-  public UnicodeString difference(final UnicodeString other, final boolean clear)
-  {
-    try {
-      final Set<Integer> difference = new LinkedHashSet<>();
-      for (int cp : codePoints) {
-        if (other.indexOf(cp) == -1) {
-          difference.add(cp);
-        }
-      }
-      return new UnicodeString(difference.stream().mapToInt(Integer::intValue).toArray());
-    } finally {
-      if (clear) {
-        clear();
+    final Set<Integer> difference = new LinkedHashSet<>();
+    for (int cp : codePoints) {
+      if (other.indexOf(cp) == -1) {
+        difference.add(cp);
       }
     }
+    return new UnicodeString(difference.stream().mapToInt(Integer::intValue).toArray());
   }
 
 

--- a/src/main/java/org/passay/UnicodeString.java
+++ b/src/main/java/org/passay/UnicodeString.java
@@ -370,8 +370,8 @@ public final class UnicodeString implements CharSequence
 
 
   /**
-   * Returns the union of this string and the other string. Union is defined as the unique set of code points in both
-   * strings.
+   * Returns the union of this string and the other string. Union is defined as the unique set of code points in either
+   * string.
    *
    * @param  other  string to intersect
    *
@@ -384,8 +384,8 @@ public final class UnicodeString implements CharSequence
 
 
   /**
-   * Returns the union of this string and the other string. Union is defined as the unique set of code points in both
-   * strings.
+   * Returns the union of this string and the other string. Union is defined as the unique set of code points in either
+   * string.
    *
    * @param  other  string to intersect
    * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method

--- a/src/main/java/org/passay/UnicodeString.java
+++ b/src/main/java/org/passay/UnicodeString.java
@@ -2,7 +2,9 @@
 package org.passay;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 /**
@@ -323,6 +325,148 @@ public final class UnicodeString implements CharSequence
         clear();
       }
     }
+  }
+
+
+  /**
+   * Returns the intersection of this string and the other string. Intersection is defined as the unique set of code
+   * points that both strings have in common.
+   *
+   * @param  other  string to intersect
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString intersection(final UnicodeString other)
+  {
+    return intersection(other, false);
+  }
+
+
+  /**
+   * Returns the intersection of this string and the other string. Intersection is defined as the unique set of code
+   * points that both strings have in common.
+   *
+   * @param  other  string to intersect
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString intersection(final UnicodeString other, final boolean clear)
+  {
+    try {
+      final Set<Integer> intersection = new LinkedHashSet<>();
+      for (int cp : codePoints) {
+        if (other.indexOf(cp) != -1) {
+          intersection.add(cp);
+        }
+      }
+      return new UnicodeString(intersection.stream().mapToInt(Integer::intValue).toArray());
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Returns the union of this string and the other string. Union is defined as the unique set of code points in both
+   * strings.
+   *
+   * @param  other  string to intersect
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString union(final UnicodeString other)
+  {
+    return union(other, false);
+  }
+
+
+  /**
+   * Returns the union of this string and the other string. Union is defined as the unique set of code points in both
+   * strings.
+   *
+   * @param  other  string to intersect
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString union(final UnicodeString other, final boolean clear)
+  {
+    try {
+      final Set<Integer> union = new LinkedHashSet<>();
+      for (int cp : codePoints) {
+        union.add(cp);
+      }
+      for (int cp : other.toCodePointArray()) {
+        union.add(cp);
+      }
+      return new UnicodeString(union.stream().mapToInt(Integer::intValue).toArray());
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Returns the difference of this string and the other string. Difference is defined as the unique set of code points
+   * that are in this string but not in the other string.
+   *
+   * @param  other  string to difference
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString difference(final UnicodeString other)
+  {
+    return difference(other, false);
+  }
+
+
+  /**
+   * Returns the difference of this string and the other string. Difference is defined as the unique set of code points
+   * that are in this string but not in the other string.
+   *
+   * @param  other  string to difference
+   * @param  clear  whether to invoke {@link #clear()} at the conclusion of this method
+   *
+   * @return  new unicode string
+   */
+  public UnicodeString difference(final UnicodeString other, final boolean clear)
+  {
+    try {
+      final Set<Integer> difference = new LinkedHashSet<>();
+      for (int cp : codePoints) {
+        if (other.indexOf(cp) == -1) {
+          difference.add(cp);
+        }
+      }
+      return new UnicodeString(difference.stream().mapToInt(Integer::intValue).toArray());
+    } finally {
+      if (clear) {
+        clear();
+      }
+    }
+  }
+
+
+  /**
+   * Returns the array index of the supplied code point in this code points array.
+   *
+   * @param  codePoint  to search for
+   *
+   * @return  array index
+   */
+  private int indexOf(final int codePoint)
+  {
+    for (int i = 0; i < codePoints.length; i++) {
+      if (codePoints[i] == codePoint) {
+        return i;
+      }
+    }
+    return -1;
   }
 
 

--- a/src/main/java/org/passay/generate/CharacterAppender.java
+++ b/src/main/java/org/passay/generate/CharacterAppender.java
@@ -1,0 +1,31 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.generate;
+
+import java.nio.CharBuffer;
+import org.passay.UnicodeString;
+
+/**
+ * Interface for appending characters to a character buffer.
+ *
+ * @author  Middleware Services
+ */
+public interface CharacterAppender
+{
+
+
+  /**
+   * Returns the characters that may be used in by this appender.
+   *
+   * @return  valid characters
+   */
+  UnicodeString getCharacters();
+
+
+  /**
+   * Fills the target buffer with at most count characters from this appender.
+   *
+   * @param  target  buffer to add characters to
+   * @param  count  maximum number of characters to add to buffer
+   */
+  void append(CharBuffer target, int count);
+}

--- a/src/main/java/org/passay/generate/CharacterCharacteristicsAppender.java
+++ b/src/main/java/org/passay/generate/CharacterCharacteristicsAppender.java
@@ -1,0 +1,72 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.generate;
+
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import org.passay.UnicodeString;
+import org.passay.rule.CharacterCharacteristicsRule;
+
+/**
+ * Character appender for {@link CharacterCharacteristicsRule}.
+ *
+ * @author  Middleware Services
+ */
+public class CharacterCharacteristicsAppender implements CharacterAppender
+{
+  /** Number of characteristics. */
+  private final int numberOfCharacteristics;
+
+  /** Character rule appenders. */
+  private final List<CharacterRuleAppender> appenders;
+
+  /** To select random characters. */
+  private final Random random;
+
+
+  /**
+   * Creates a new character characteristics appender.
+   *
+   * @param  rule  to build appender from
+   * @param  allowedChars  characters allowed in password generation
+   * @param  illegalChars  characters not allowed in password generation
+   * @param  rand  to randomize character selection
+   */
+  public CharacterCharacteristicsAppender(
+    final CharacterCharacteristicsRule rule,
+    final UnicodeString allowedChars,
+    final UnicodeString illegalChars,
+    final Random rand)
+  {
+    numberOfCharacteristics = rule.getNumberOfCharacteristics();
+    appenders = rule.getRules().stream()
+      .map(r -> new CharacterRuleAppender(r, allowedChars, illegalChars, rand))
+      .collect(Collectors.toList());
+    random = rand;
+  }
+
+
+  @Override
+  public UnicodeString getCharacters()
+  {
+    UnicodeString characters = appenders.get(0).getCharacters();
+    for (int i = 1; i < appenders.size(); i++) {
+      characters = characters.union(appenders.get(i).getCharacters());
+    }
+    return characters;
+  }
+
+
+  @Override
+  public void append(final CharBuffer target, final int count)
+  {
+    final List<CharacterRuleAppender> randomAppender = new ArrayList<>(appenders);
+    Collections.shuffle(randomAppender, random);
+    for (int i = 0; i < numberOfCharacteristics; i++) {
+      randomAppender.get(i).append(target, count);
+    }
+  }
+}

--- a/src/main/java/org/passay/generate/CharacterRuleAppender.java
+++ b/src/main/java/org/passay/generate/CharacterRuleAppender.java
@@ -1,0 +1,63 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.generate;
+
+import java.nio.CharBuffer;
+import java.util.Random;
+import org.passay.PassayUtils;
+import org.passay.UnicodeString;
+import org.passay.rule.CharacterRule;
+
+/**
+ * Character appender for {@link CharacterRule}.
+ *
+ * @author  Middleware Services
+ */
+public class CharacterRuleAppender implements CharacterAppender
+{
+  /** Number of characters. */
+  private final int numberOfCharacters;
+
+  /** Valid characters. */
+  private final UnicodeString characters;
+
+  /** To select random characters. */
+  private final Random random;
+
+
+  /**
+   * Creates a new character rule appender.
+   *
+   * @param  rule  to build appender from
+   * @param  allowedChars  characters allowed for appending
+   * @param  illegalChars  characters not allowed for appending
+   * @param  rand  to randomize character selection
+   */
+  public CharacterRuleAppender(
+    final CharacterRule rule, final UnicodeString allowedChars, final UnicodeString illegalChars, final Random rand)
+  {
+    numberOfCharacters = rule.getNumberOfCharacters();
+    UnicodeString validChars = new UnicodeString(rule.getValidCharacters());
+    if (!allowedChars.isEmpty()) {
+      validChars = validChars.intersection(allowedChars);
+    }
+    if (!illegalChars.isEmpty()) {
+      validChars = validChars.difference(illegalChars);
+    }
+    characters = validChars;
+    random = rand;
+  }
+
+
+  @Override
+  public UnicodeString getCharacters()
+  {
+    return characters;
+  }
+
+
+  @Override
+  public void append(final CharBuffer target, final int count)
+  {
+    PassayUtils.appendRandomCharacters(characters, target, Math.min(count, numberOfCharacters), random);
+  }
+}

--- a/src/main/java/org/passay/generate/FillRemainingCharactersAppender.java
+++ b/src/main/java/org/passay/generate/FillRemainingCharactersAppender.java
@@ -1,0 +1,107 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.passay.generate;
+
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.passay.PassayUtils;
+import org.passay.UnicodeString;
+import org.passay.rule.CharacterCharacteristicsRule;
+import org.passay.rule.CharacterRule;
+import org.passay.rule.Rule;
+
+/**
+ * Character appender for filling a password with valid characters. This appender should be the last to execute for
+ * password generation.
+ *
+ * @author  Middleware Services
+ */
+public class FillRemainingCharactersAppender implements CharacterAppender
+{
+  /** Valid characters. */
+  private final UnicodeString characters;
+
+  /** To select random characters. */
+  private final Random random;
+
+
+  /**
+   * Creates a new fill appender.
+   *
+   * @param  rules  to derive characters from
+   * @param  allowedChars  characters allowed for appending
+   * @param  illegalChars  characters not allowed for appending
+   * @param  rand  to randomize character selection
+   */
+  public FillRemainingCharactersAppender(
+    final List<? extends Rule> rules,
+    final UnicodeString allowedChars,
+    final UnicodeString illegalChars,
+    final Random rand)
+  {
+    if (!allowedChars.isEmpty()) {
+      if (!illegalChars.isEmpty()) {
+        characters = allowedChars.difference(illegalChars);
+      } else {
+        characters = allowedChars;
+      }
+    } else {
+      // characters defined in all CharacterRules
+      final UnicodeString chars = getCharacters(rules);
+      if (!chars.isEmpty()) {
+        if (!illegalChars.isEmpty()) {
+          characters = chars.difference(illegalChars);
+        } else {
+          characters = chars;
+        }
+      } else {
+        characters = new UnicodeString();
+      }
+    }
+    random = rand;
+  }
+
+
+  /**
+   * Return a unicode string that contains the unique characters from all {@link CharacterRule} or
+   * {@link CharacterCharacteristicsRule} contained in the supplied list.
+   *
+   * @param  rules  to extract unique characters from
+   *
+   * @return  unicode string containing unique characters or empty string
+   */
+  private UnicodeString getCharacters(final List<? extends Rule> rules)
+  {
+    final List<CharacterRule> characterRules = new ArrayList<>();
+    for (Rule rule : rules) {
+      if (rule instanceof CharacterRule) {
+        characterRules.add((CharacterRule) rule);
+      } else if (rule instanceof CharacterCharacteristicsRule) {
+        characterRules.addAll(((CharacterCharacteristicsRule) rule).getRules());
+      }
+    }
+    UnicodeString chars = null;
+    if (!characterRules.isEmpty()) {
+      chars = new UnicodeString(characterRules.get(0).getValidCharacters());
+      for (int i = 1; i < characterRules.size(); i++) {
+        chars = chars.union(new UnicodeString(characterRules.get(i).getValidCharacters()));
+      }
+    }
+    return chars != null ? chars : new UnicodeString();
+  }
+
+
+  @Override
+  public UnicodeString getCharacters()
+  {
+    return characters;
+  }
+
+
+  @Override
+  public void append(final CharBuffer target, final int count)
+  {
+    PassayUtils.appendRandomCharacters(characters, target, count, random);
+  }
+}

--- a/src/main/java/org/passay/rule/IllegalSequenceRule.java
+++ b/src/main/java/org/passay/rule/IllegalSequenceRule.java
@@ -59,6 +59,18 @@ public class IllegalSequenceRule implements Rule
    *
    * @param  data  sequence data for this rule
    * @param  length  sequence length
+   */
+  public IllegalSequenceRule(final SequenceData data, final int length)
+  {
+    this(data, length, false, true);
+  }
+
+
+  /**
+   * Creates a new sequence rule with the supplied list of characters.
+   *
+   * @param  data  sequence data for this rule
+   * @param  length  sequence length
    * @param  wrap  whether to wrap sequences
    */
   public IllegalSequenceRule(final SequenceData data, final int length, final boolean wrap)

--- a/src/test/java/org/passay/HeapDump.java
+++ b/src/test/java/org/passay/HeapDump.java
@@ -18,6 +18,7 @@ import org.passay.dictionary.Dictionary;
 import org.passay.dictionary.WordListDictionary;
 import org.passay.dictionary.WordLists;
 import org.passay.dictionary.sort.ArraysSort;
+import org.passay.generate.PasswordGenerator;
 import org.passay.rule.AllowedCharacterRule;
 import org.passay.rule.AllowedRegexRule;
 import org.passay.rule.CharacterCharacteristicsRule;

--- a/src/test/java/org/passay/HeapDump.java
+++ b/src/test/java/org/passay/HeapDump.java
@@ -183,12 +183,12 @@ public final class HeapDump
    */
   public static void generatePassword()
   {
-    final PasswordGenerator generator = new PasswordGenerator();
-    final UnicodeString password = generator.generatePassword(
+    final PasswordGenerator generator = new PasswordGenerator(
       22,
       new CharacterRule(EnglishCharacterData.Digit, 1),
       new CharacterRule(EnglishCharacterData.UpperCase, 1),
       new CharacterRule(EnglishCharacterData.LowerCase, 20));
+    final UnicodeString password = generator.generate();
     try {
       printPassword("Generated password", password);
     } finally {

--- a/src/test/java/org/passay/PasswordGeneratorTest.java
+++ b/src/test/java/org/passay/PasswordGeneratorTest.java
@@ -7,8 +7,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.passay.data.EnglishCharacterData;
 import org.passay.data.EnglishSequenceData;
+import org.passay.rule.AllowedCharacterRule;
 import org.passay.rule.CharacterCharacteristicsRule;
 import org.passay.rule.CharacterRule;
+import org.passay.rule.IllegalCharacterRule;
 import org.passay.rule.IllegalSequenceRule;
 import org.passay.rule.RepeatCharactersRule;
 import org.passay.rule.Rule;
@@ -44,6 +46,34 @@ public class PasswordGeneratorTest
         new CharacterRule(EnglishCharacterData.LowerCase, 3),
         new RepeatCharactersRule(3, 1),
       },
+      new Object[] {
+        new CharacterRule(EnglishCharacterData.Digit, 3),
+        new AllowedCharacterRule(
+          new UnicodeString(
+            '0', '1', '2', '3', '4', '5',
+            'a', 'b', 'c', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'x', 'y', 'z')),
+        new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
+      },
+      new Object[] {
+        new CharacterRule(EnglishCharacterData.Digit, 1),
+        new CharacterCharacteristicsRule(
+          new CharacterRule(EnglishCharacterData.UpperCase, 2),
+          new CharacterRule(EnglishCharacterData.LowerCase, 3)),
+        new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
+      },
+      new Object[] {
+        new CharacterRule(EnglishCharacterData.Digit, 1),
+        new CharacterCharacteristicsRule(
+          new CharacterRule(EnglishCharacterData.UpperCase, 1),
+          new CharacterRule(EnglishCharacterData.LowerCase, 1),
+          new CharacterRule(EnglishCharacterData.SpecialAscii, 1)),
+        new AllowedCharacterRule(new UnicodeString(
+          '0', '1', '2', '3', '4', '5',
+          'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',  'M', 'N', 'O', 'P',
+          'k',  'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+          '!', '@', '#', '^', '&', '*')),
+        new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
+      },
     };
   }
 
@@ -64,11 +94,11 @@ public class PasswordGeneratorTest
     extendedSet.add(new CharacterRule(EnglishCharacterData.SpecialUnicode, 1));
     final List<Rule> failRules = addCharacteristics(extendedSet);
     final DefaultPasswordValidator failValidator = new DefaultPasswordValidator(failRules);
-    final PasswordGenerator generator = new PasswordGenerator();
+    final PasswordGenerator generator = new PasswordGenerator(22, ruleSet);
     // Perform a number of rounds likely to produce illegal sequences by random chance
     try {
       for (int i = 0; i < 500000; i++) {
-        final UnicodeString password = generator.generatePassword(22, ruleSet);
+        final UnicodeString password = generator.generate();
         final PasswordData pd = new PasswordData(password);
         assertThat(passValidator.validate(pd).isValid()).isTrue();
         assertThat(failValidator.validate(pd).isValid()).isFalse();
@@ -84,21 +114,85 @@ public class PasswordGeneratorTest
   }
 
   @Test(groups = "passgentest")
+  public void testInvalidRuleCombination()
+  {
+    try {
+      new PasswordGenerator(
+        5,
+        new AllowedCharacterRule(new UnicodeString('a', 'b', 'c')),
+        new IllegalCharacterRule(new UnicodeString('a', 'b', 'c')));
+      fail("Should have thrown IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getMessage()).isEqualTo("Rules did not produce any combination of valid characters");
+    }
+
+    try {
+      new PasswordGenerator(
+        5,
+        new AllowedCharacterRule(new UnicodeString('a', 'b', 'c')),
+        new AllowedCharacterRule(new UnicodeString('x', 'y', 'z')));
+      fail("Should have thrown IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getMessage()).isEqualTo("Rules did not produce any combination of valid characters");
+    }
+
+    try {
+      new PasswordGenerator(
+        5,
+        new CharacterRule(EnglishCharacterData.Digit, 1),
+        new CharacterRule(EnglishCharacterData.UpperCase, 1),
+        new AllowedCharacterRule(new UnicodeString('a', 'b', 'c', 'd', 'e', 'f')));
+      fail("Should have thrown IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getMessage()).isEqualTo("Rules did not produce any combination of valid characters");
+    }
+
+    try {
+      new PasswordGenerator(
+        5,
+        new CharacterCharacteristicsRule(
+          1,
+          new CharacterRule(EnglishCharacterData.Digit, 1),
+          new CharacterRule(EnglishCharacterData.UpperCase, 1)),
+        new AllowedCharacterRule(new UnicodeString('a', 'b', 'c', 'd', 'e', 'f')));
+      fail("Should have thrown IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getMessage()).isEqualTo("Rules did not produce any combination of valid characters");
+    }
+
+    try {
+      new PasswordGenerator(
+        5,
+        new CharacterRule(EnglishCharacterData.Digit, 1),
+        new IllegalCharacterRule(new UnicodeString('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')));
+      fail("Should have thrown IllegalArgumentException");
+    } catch (Exception e) {
+      assertThat(e).isExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getMessage()).isEqualTo("Rules did not produce any combination of valid characters");
+    }
+  }
+
+
+  @Test(groups = "passgentest")
   public void testBufferOverflow()
   {
     try {
-      new PasswordGenerator().generatePassword(5, new CharacterRule(EnglishCharacterData.LowerCase, 10));
+      new PasswordGenerator(5, new CharacterRule(EnglishCharacterData.LowerCase, 10)).generate();
       fail("Should have thrown IllegalStateException");
     } catch (IllegalStateException e) {
       if (!e.getMessage().equals("Exceeded maximum number of password generation retries")) {
         fail("Unexpected error message: %s", e.getMessage());
       }
     }
-    new PasswordGenerator().generatePassword(10, new CharacterRule(EnglishCharacterData.LowerCase, 5));
-    new PasswordGenerator().generatePassword(10, new CharacterRule(EnglishCharacterData.LowerCase, 10));
+    new PasswordGenerator(10, new CharacterRule(EnglishCharacterData.LowerCase, 5)).generate();
+    new PasswordGenerator(10, new CharacterRule(EnglishCharacterData.LowerCase, 10)).generate();
     try {
       // cannot generate password with odd number of characters using unicode input (every char has length of 2)
-      new PasswordGenerator().generatePassword(9, new CharacterRule(EnglishCharacterData.SpecialLatin, 10));
+      new PasswordGenerator(9, new CharacterRule(EnglishCharacterData.SpecialLatin, 10)).generate();
       fail("Should have thrown IllegalStateException");
     } catch (IllegalStateException e) {
       if (!e.getMessage().equals("Exceeded maximum number of password generation retries")) {

--- a/src/test/java/org/passay/PasswordGeneratorTest.java
+++ b/src/test/java/org/passay/PasswordGeneratorTest.java
@@ -50,9 +50,8 @@ public class PasswordGeneratorTest
         new CharacterRule(EnglishCharacterData.Digit, 3),
         new AllowedCharacterRule(
           new UnicodeString(
-            '0', '1', '2', '3', '4', '5',
-            'a', 'b', 'c', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'x', 'y', 'z')),
-        new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
+            EnglishCharacterData.Digit.getCharacters() + EnglishCharacterData.Alphabetical.getCharacters())),
+        new IllegalSequenceRule(EnglishSequenceData.Numerical, 3),
       },
       new Object[] {
         new CharacterRule(EnglishCharacterData.Digit, 1),
@@ -67,12 +66,9 @@ public class PasswordGeneratorTest
           new CharacterRule(EnglishCharacterData.UpperCase, 1),
           new CharacterRule(EnglishCharacterData.LowerCase, 1),
           new CharacterRule(EnglishCharacterData.SpecialAscii, 1)),
-        new AllowedCharacterRule(new UnicodeString(
-          '0', '1', '2', '3', '4', '5',
-          'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',  'M', 'N', 'O', 'P',
-          'k',  'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-          '!', '@', '#', '^', '&', '*')),
-        new IllegalSequenceRule(EnglishSequenceData.Alphabetical),
+        new AllowedCharacterRule(
+          new UnicodeString("012345" + EnglishCharacterData.Alphabetical.getCharacters() + "!@#^&*")),
+        new IllegalSequenceRule(EnglishSequenceData.Alphabetical, 3),
       },
     };
   }
@@ -104,11 +100,7 @@ public class PasswordGeneratorTest
         assertThat(failValidator.validate(pd).isValid()).isFalse();
       }
     } catch (IllegalStateException e) {
-      if (e.getMessage().equals("Exceeded maximum number of password generation retries")) {
-        fail(e.getMessage());
-      } else {
-        throw e;
-      }
+      assertThat(e.getMessage()).isEqualTo("Exceeded maximum number of password generation retries");
     }
     assertThat(generator.getRetryCount()).isGreaterThan(0);
   }

--- a/src/test/java/org/passay/UnicodeStringTest.java
+++ b/src/test/java/org/passay/UnicodeStringTest.java
@@ -218,4 +218,89 @@ public class UnicodeStringTest
     assertThat(new UnicodeString("ABC12\uD83C\uDDEE\uD83C\uDDF8")
       .endsWith(new UnicodeString(127470, 127480))).isTrue();
   }
+
+
+  @Test
+  public void intersection()
+  {
+    assertThat(new UnicodeString().intersection(new UnicodeString()))
+      .isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("ABC123").intersection(new UnicodeString()))
+      .isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString().intersection(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("ABC123").intersection(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("abcdefg").intersection(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("efg"));
+    assertThat(new UnicodeString("ABC123").intersection(new UnicodeString("ZBX920")))
+      .isEqualTo(new UnicodeString("B2"));
+    assertThat(new UnicodeString("AB¢123").intersection(new UnicodeString("ZBX920")))
+      .isEqualTo(new UnicodeString("B2"));
+    assertThat(new UnicodeString("AB\uD808\uDF34123").intersection(new UnicodeString("ZBX920")))
+      .isEqualTo(new UnicodeString("B2"));
+    assertThat(new UnicodeString("AB\uD83C\uDDEE\uD83C\uDDF8123").intersection(new UnicodeString("ZBX920")))
+      .isEqualTo(new UnicodeString("B2"));
+    assertThat(new UnicodeString("AB¢123").intersection(new UnicodeString("ZBX9¢0")))
+      .isEqualTo(new UnicodeString("B¢"));
+    assertThat(new UnicodeString("AB\uD808\uDF34123").intersection(new UnicodeString("ZBX9\uD808\uDF340")))
+      .isEqualTo(new UnicodeString("B\uD808\uDF34"));
+    assertThat(new UnicodeString("AB\uD83C\uDDEE\uD83C\uDDF8123")
+      .intersection(new UnicodeString("ZBX9\uD83C\uDDEE\uD83C\uDDF80")))
+      .isEqualTo(new UnicodeString("B\uD83C\uDDEE\uD83C\uDDF8"));
+  }
+
+
+  @Test
+  public void union()
+  {
+    assertThat(new UnicodeString().union(new UnicodeString())).isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("ABC123").union(new UnicodeString()))
+      .isEqualTo(new UnicodeString("ABC123"));
+    assertThat(new UnicodeString().union(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString("XYZ098"));
+    assertThat(new UnicodeString("ABC123").union(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString("ABC123XYZ098"));
+    assertThat(new UnicodeString("abcdefg").union(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("abcdefghij"));
+    assertThat(new UnicodeString("ab¢defg").union(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab¢defghij"));
+    assertThat(new UnicodeString("ab\uD808\uDF34defg").union(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab\uD808\uDF34defghij"));
+    assertThat(new UnicodeString("ab\uD83C\uDDEE\uD83C\uDDF8defg").union(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab\uD83C\uDDEE\uD83C\uDDF8defghij"));
+    assertThat(new UnicodeString("abcdefg").union(new UnicodeString("¢fghij")))
+      .isEqualTo(new UnicodeString("abcdefg¢hij"));
+    assertThat(new UnicodeString("abcdefg").union(new UnicodeString("\uD808\uDF34fghij")))
+      .isEqualTo(new UnicodeString("abcdefg\uD808\uDF34hij"));
+    assertThat(new UnicodeString("abcdefg").union(new UnicodeString("\uD83C\uDDEE\uD83C\uDDF8fghij")))
+      .isEqualTo(new UnicodeString("abcdefg\uD83C\uDDEE\uD83C\uDDF8hij"));
+  }
+
+
+  @Test
+  public void difference()
+  {
+    assertThat(new UnicodeString().difference(new UnicodeString())).isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("ABC123").difference(new UnicodeString()))
+      .isEqualTo(new UnicodeString("ABC123"));
+    assertThat(new UnicodeString().difference(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString());
+    assertThat(new UnicodeString("ABC123").difference(new UnicodeString("XYZ098")))
+      .isEqualTo(new UnicodeString("ABC123"));
+    assertThat(new UnicodeString("abcdefg").difference(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("abcd"));
+    assertThat(new UnicodeString("ab¢defg").difference(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab¢d"));
+    assertThat(new UnicodeString("ab\uD808\uDF34defg").difference(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab\uD808\uDF34d"));
+    assertThat(new UnicodeString("ab\uD83C\uDDEE\uD83C\uDDF8defg").difference(new UnicodeString("efghij")))
+      .isEqualTo(new UnicodeString("ab\uD83C\uDDEE\uD83C\uDDF8d"));
+    assertThat(new UnicodeString("abcdefg").difference(new UnicodeString("¢fghij")))
+      .isEqualTo(new UnicodeString("abcde"));
+    assertThat(new UnicodeString("abcdefg").difference(new UnicodeString("\uD808\uDF34fghij")))
+      .isEqualTo(new UnicodeString("abcde"));
+    assertThat(new UnicodeString("abcdefg").difference(new UnicodeString("\uD83C\uDDEE\uD83C\uDDF8fghij")))
+      .isEqualTo(new UnicodeString("abcde"));
+  }
 }

--- a/src/test/java/org/passay/generate/PasswordGeneratorTest.java
+++ b/src/test/java/org/passay/generate/PasswordGeneratorTest.java
@@ -1,10 +1,13 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
-package org.passay;
+package org.passay.generate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.passay.DefaultPasswordValidator;
+import org.passay.PasswordData;
+import org.passay.UnicodeString;
 import org.passay.data.EnglishCharacterData;
 import org.passay.data.EnglishSequenceData;
 import org.passay.rule.AllowedCharacterRule;


### PR DESCRIPTION
Add support for leveraging Allowed and Illegal Character rules when generating passwords. Add PasswordGenerator.CharacterAppender interface to support extension. Rename PasswordGenerator#generatePassword to PasswordGenerator#generate and change to a no-args stateful implementation. Update UnicodePassword to support set operations on its characters. Fixes #40.
Fixes #145.